### PR TITLE
Fix compile error with kp_space_time_stack.cpp

### DIFF
--- a/src/tools/space-time-stack/kp_space_time_stack.cpp
+++ b/src/tools/space-time-stack/kp_space_time_stack.cpp
@@ -394,7 +394,7 @@ struct Allocations {
       MPI_Irecv(const_cast<char*>(s.data()), string_size, MPI_CHAR, min_max_rank, 42, MPI_COMM_WORLD, &request);
     }
     if (rank == min_max_rank) {
-      MPI_Send(s.data(), string_size, MPI_CHAR, 0, 42, MPI_COMM_WORLD);
+      MPI_Send(const_cast<char*>(s.data()), string_size, MPI_CHAR, 0, 42, MPI_COMM_WORLD);
     }
     if (rank == 0) {
       MPI_Wait(&request, MPI_STATUS_IGNORE);


### PR DESCRIPTION
Clang on BG/Q errors out and won't compile `kp_space_time_stack.cpp` without this change, see Issue #29 