### PR TITLE
Remove macro definition from Makefile as suggested by @mhoemmen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+*~
 *.so
 /src/tools/simple-kernel-timer/kp_reader

--- a/src/tools/simple-kernel-timer-json/kp_kernel_timer.cpp
+++ b/src/tools/simple-kernel-timer-json/kp_kernel_timer.cpp
@@ -9,7 +9,7 @@
 #include <algorithm>
 #include <string>
 #include <sys/time.h>
-#include <cxxabi.h>
+
 #include <unistd.h>
 #include "kp_kernel_info.h"
 

--- a/src/tools/simple-kernel-timer/Makefile
+++ b/src/tools/simple-kernel-timer/Makefile
@@ -1,8 +1,6 @@
 CXX=g++
 CXXFLAGS=-O3 -std=c++11 -g
 SHARED_CXXFLAGS=-shared -fPIC
-# comment the following line if abi::__cxa_demangle is not supported by your compiler
-CXXFLAGS+= -DHAVE_GCC_ABI_DEMANGLE
 
 all: kp_kernel_timer.so kp_reader
 

--- a/src/tools/simple-kernel-timer/kp_kernel_timer.cpp
+++ b/src/tools/simple-kernel-timer/kp_kernel_timer.cpp
@@ -9,7 +9,7 @@
 #include <algorithm>
 #include <string>
 #include <sys/time.h>
-#include <cxxabi.h>
+
 #include <unistd.h>
 #include "kp_kernel_info.h"
 
@@ -80,13 +80,13 @@ extern "C" void kokkosp_init_library(const int loadSeq,
 extern "C" void kokkosp_finalize_library() {
 	double finishTime = seconds();
 	double kernelTimes = 0;
-	
+
 	char* hostname = (char*) malloc(sizeof(char) * 256);
 	gethostname(hostname, 256);
-	
+
 	char* fileOutput = (char*) malloc(sizeof(char) * 256);
 	sprintf(fileOutput, "%s-%d.dat", hostname, (int) getpid());
-	
+
 	free(hostname);
 	FILE* output_data = fopen(fileOutput, "wb");
 
@@ -214,8 +214,8 @@ extern "C" void kokkosp_finalize_library() {
 	if(NULL != outputDelimiter) {
 		free(outputDelimiter);
 	}*/
-	
-	
+
+
 }
 
 extern "C" void kokkosp_begin_parallel_for(const char* name, const uint32_t devID, uint64_t* kID) {
@@ -271,4 +271,3 @@ extern "C" void kokkosp_pop_profile_region() {
         current_region_level--;
         regions[current_region_level]->addFromTimer();
 }
-


### PR DESCRIPTION
- check for __GXX_ABI_VERSION.
- create demangleName C-like function
- report this changes to simple-kernel-timer-json