### PR TITLE
space-time-stack: use #if USE_MPI instead of #ifdef

### DIFF
--- a/src/tools/space-time-stack/kp_space_time_stack.cpp
+++ b/src/tools/space-time-stack/kp_space_time_stack.cpp
@@ -461,7 +461,7 @@ struct State {
     auto inv_stack_root = stack_root.invert();
     stack_root.reduce_over_mpi();
     inv_stack_root.reduce_over_mpi();
-#ifdef USE_MPI
+#if USE_MPI
     int rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     if (rank == 0)


### PR DESCRIPTION
Credit due: @dalg24