### PR TITLE
Wcohen/systemtap

### DIFF
--- a/src/tools/systemtap-connector/Makefile
+++ b/src/tools/systemtap-connector/Makefile
@@ -1,0 +1,18 @@
+CXX=g++
+CXXFLAGS=-O3 -std=c++11 -g
+SHARED_CXXFLAGS=-shared -fPIC
+
+all: kp_systemtap_connector.so
+
+probes.h: probes.d
+	dtrace -C -h -s $< -o $@
+
+probes.o: probes.d
+	dtrace -C -G -s $< -o $@
+
+kp_systemtap_connector.so: kp_systemtap_connector.cpp probes.h probes.o
+	$(CXX) $(SHARED_CXXFLAGS) $(CXXFLAGS) $(LDFLAGS) probes.o \
+		-o $@ kp_systemtap_connector.cpp $(LIBS)
+
+clean:
+	rm -rf *.so probes.h probes.o

--- a/src/tools/systemtap-connector/kokkos_stap_deep_copy.stp
+++ b/src/tools/systemtap-connector/kokkos_stap_deep_copy.stp
@@ -1,0 +1,25 @@
+global start_t
+global stats
+
+probe process("./kp_systemtap_connector.so").mark("begin_deep_copy")
+{
+  start_t[pid()] = gettimeofday_ns();
+}
+
+probe process("./kp_systemtap_connector.so").mark("end_deep_copy")
+{
+  id = pid()
+  if (id in start_t) {
+     stats[id] <<< gettimeofday_ns() -  start_t[id]
+     delete start_t[id]
+  }
+}
+
+probe end
+{
+  printf("\n\n")
+  foreach ([id] in stats) {
+    printf ("%s, %d \n", "", id)
+    print (@hist_log(stats[id]))
+  }
+}

--- a/src/tools/systemtap-connector/kokkos_stap_example1.stp
+++ b/src/tools/systemtap-connector/kokkos_stap_example1.stp
@@ -1,0 +1,27 @@
+global start_t, names%
+global stats%
+
+probe process("./kp_systemtap_connector.so").mark("begin_parallel_*")
+{
+  kernid = user_int($arg3)
+  names[kernid] = user_string_quoted($arg1)
+  start_t[pid(), kernid] = gettimeofday_ns();
+}
+
+probe process("./kp_systemtap_connector.so").mark("end_parallel_*")
+{
+  kernid = $arg1
+  if ([pid(), kernid] in start_t) {
+    stats[execname(), pn(), names[kernid]] <<< gettimeofday_ns() -  start_t[pid(),kernid]
+    delete start_t[pid(), kernid]
+  }
+}
+
+probe end
+{
+  printf("\n\n")
+  foreach ([e, op, name] in stats) {
+    printf ("execname:%s op:%s name:%s \n", e, op, name)
+    print (@hist_log(stats[e, op, name]))
+  }
+}

--- a/src/tools/systemtap-connector/kokkos_stap_mon.stp
+++ b/src/tools/systemtap-connector/kokkos_stap_mon.stp
@@ -1,0 +1,34 @@
+// A really simple script to demonstrate how to use the systemtap connector
+// to generate prometheus monitoring data for the Kokkos parallel_scan,
+// parallel_reduce, and parallel_for.
+
+global start_t, names%
+global stats%
+
+probe process("./kp_systemtap_connector.so").mark("begin_parallel_*")
+{
+  kernid = user_int($arg3)
+  names[kernid] = user_string_quoted($arg1)
+  start_t[pid(), kernid] = gettimeofday_ns();
+}
+
+probe process("./kp_systemtap_connector.so").mark("end_parallel_*")
+{
+  kernid = $arg1
+  if ([pid(), kernid] in start_t) {
+    stats[execname(), names[kernid]] <<< gettimeofday_ns() -  start_t[pid(),kernid]
+    delete start_t[pid(), kernid]
+  }
+}
+
+global prom_arr
+
+probe prometheus
+{
+  foreach ([e, name] in stats) {
+    prom_arr[name, @count(stats[e, name]), @sum(stats[e, name])] = e
+  }
+  @prometheus_dump_array3(prom_arr, "kokkos_info", "operation", "op_count",
+			  "op_time")
+ delete prom_arr
+}

--- a/src/tools/systemtap-connector/kp_systemtap_connector.cpp
+++ b/src/tools/systemtap-connector/kp_systemtap_connector.cpp
@@ -16,6 +16,7 @@ struct SpaceHandle {
 };
 
 static uint64_t next_kernid;
+static uint32_t next_sec_id;
 
 extern "C" void kokkosp_begin_parallel_for(const char* name, const uint32_t devid, uint64_t* kernid)
 {
@@ -128,6 +129,7 @@ extern "C" void kokkosp_end_deep_copy()
       
 extern "C" void kokkosp_create_profile_section(const char* name, uint32_t* sec_id)
 {
+  *sec_id = next_sec_id++;
   if (KOKKOS_CREATE_PROFILE_SECTION_ENABLED()) {
     KOKKOS_CREATE_PROFILE_SECTION(name, sec_id);
   }

--- a/src/tools/systemtap-connector/kp_systemtap_connector.cpp
+++ b/src/tools/systemtap-connector/kp_systemtap_connector.cpp
@@ -15,8 +15,11 @@ struct SpaceHandle {
   char name[64];                                                                        
 };
 
+static uint64_t next_kernid;
+
 extern "C" void kokkosp_begin_parallel_for(const char* name, const uint32_t devid, uint64_t* kernid)
 {
+  *kernid = next_kernid++;
   if ( KOKKOS_END_PARALLEL_FOR_ENABLED()) {
     KOKKOS_BEGIN_PARALLEL_FOR(name, devid, kernid);
   }
@@ -24,6 +27,7 @@ extern "C" void kokkosp_begin_parallel_for(const char* name, const uint32_t devi
 
 extern "C" void kokkosp_begin_parallel_scan(const char* name, const uint32_t devid, uint64_t* kernid)
 {
+  *kernid = next_kernid++;
   if (KOKKOS_BEGIN_PARALLEL_SCAN_ENABLED()) {
     KOKKOS_BEGIN_PARALLEL_SCAN(name, devid, kernid);
   }
@@ -31,6 +35,7 @@ extern "C" void kokkosp_begin_parallel_scan(const char* name, const uint32_t dev
 
 extern "C" void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devid, uint64_t* kernid)
 {
+  *kernid = next_kernid++;
   if (KOKKOS_BEGIN_PARALLEL_REDUCE_ENABLED()) {
     KOKKOS_BEGIN_PARALLEL_REDUCE(name, devid, kernid);
   }

--- a/src/tools/systemtap-connector/kp_systemtap_connector.cpp
+++ b/src/tools/systemtap-connector/kp_systemtap_connector.cpp
@@ -1,0 +1,157 @@
+#include <stdio.h>
+#include <inttypes.h>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+#include <unordered_set>
+#include <string>
+#include <regex>
+#include <cxxabi.h>
+#include <dlfcn.h>
+
+#include "probes.h"
+
+struct SpaceHandle {
+  char name[64];                                                                        
+};
+
+extern "C" void kokkosp_begin_parallel_for(const char* name, const uint32_t devid, uint64_t* kernid)
+{
+  if ( KOKKOS_END_PARALLEL_FOR_ENABLED()) {
+    KOKKOS_BEGIN_PARALLEL_FOR(name, devid, kernid);
+  }
+}
+
+extern "C" void kokkosp_begin_parallel_scan(const char* name, const uint32_t devid, uint64_t* kernid)
+{
+  if (KOKKOS_BEGIN_PARALLEL_SCAN_ENABLED()) {
+    KOKKOS_BEGIN_PARALLEL_SCAN(name, devid, kernid);
+  }
+}
+
+extern "C" void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devid, uint64_t* kernid)
+{
+  if (KOKKOS_BEGIN_PARALLEL_REDUCE_ENABLED()) {
+    KOKKOS_BEGIN_PARALLEL_REDUCE(name, devid, kernid);
+  }
+}
+
+extern "C" void kokkosp_end_parallel_scan(uint64_t kernid)
+{
+  if (KOKKOS_END_PARALLEL_SCAN_ENABLED()) {
+    KOKKOS_END_PARALLEL_SCAN(kernid);
+  }
+}
+
+extern "C" void kokkosp_end_parallel_for(uint64_t kernid)
+{
+  if (KOKKOS_END_PARALLEL_FOR_ENABLED()) {
+    KOKKOS_END_PARALLEL_FOR(kernid);
+  }
+}
+
+extern "C" void kokkosp_end_parallel_reduce(uint64_t kernid)
+{
+  if (KOKKOS_END_PARALLEL_REDUCE_ENABLED()) {
+    KOKKOS_END_PARALLEL_REDUCE(kernid);
+  }
+}
+
+extern "C" void kokkosp_init_library(const int loadseq,
+	const uint64_t version,
+	const uint32_t ndevinfos,
+	void* deviceinfos)
+{
+  if (KOKKOS_INIT_LIBRARY_ENABLED()) {
+    KOKKOS_INIT_LIBRARY(loadseq, version, ndevinfos, deviceinfos);
+  }
+}
+
+extern "C" void kokkosp_finalize_library()
+{
+  if (KOKKOS_FINALIZE_LIBRARY_ENABLED()) {
+    KOKKOS_FINALIZE_LIBRARY();
+  }
+}
+
+extern "C" void kokkosp_push_profile_region(const char* name)
+{
+  if (KOKKOS_PUSH_PROFILE_REGION_ENABLED()) {
+    KOKKOS_PUSH_PROFILE_REGION(name);
+  }
+}
+
+extern "C" void kokkosp_pop_profile_region()
+{
+  if (KOKKOS_POP_PROFILE_REGION_ENABLED()) {
+    KOKKOS_POP_PROFILE_REGION();
+  }
+}
+
+extern "C" void kokkosp_allocate_data(SpaceHandle handle, const char* name, void* ptr, uint64_t size)
+{
+  if (KOKKOS_ALLOCATE_DATA_ENABLED()) {
+    KOKKOS_ALLOCATE_DATA(handle, name, ptr, size);
+  }
+}
+
+extern "C" void kokkosp_deallocate_data(SpaceHandle handle, const char* name, void* ptr, uint64_t size)
+{
+  if (KOKKOS_DEALLOCATE_DATA_ENABLED()) {
+    KOKKOS_DEALLOCATE_DATA(handle, name, ptr, size);
+  }
+}
+
+extern "C" void kokkosp_begin_deep_copy(
+    SpaceHandle dst_handle, const char* dst_name, const void* dst_ptr,
+    SpaceHandle src_handle, const char* src_name, const void* src_ptr,
+    uint64_t size)
+{
+  if (KOKKOS_BEGIN_DEEP_COPY_ENABLED()) {
+    KOKKOS_BEGIN_DEEP_COPY(dst_handle, dst_name, dst_ptr,
+                      src_handle, src_name, src_ptr,
+                      size);
+  }
+}
+
+extern "C" void kokkosp_end_deep_copy()
+{
+  if (KOKKOS_END_DEEP_COPY_ENABLED()) {
+    KOKKOS_END_DEEP_COPY();
+  }
+}
+      
+extern "C" void kokkosp_create_profile_section(const char* name, uint32_t* sec_id)
+{
+  if (KOKKOS_CREATE_PROFILE_SECTION_ENABLED()) {
+    KOKKOS_CREATE_PROFILE_SECTION(name, sec_id);
+  }
+}
+
+extern "C" void kokkosp_start_profile_section(const uint32_t sec_id)
+{
+  if (KOKKOS_START_PROFILE_SECTION_ENABLED()) {
+    KOKKOS_START_PROFILE_SECTION(sec_id);
+  }
+}
+
+extern "C" void kokkosp_stop_profile_section(const uint32_t sec_id)
+{
+  if (KOKKOS_STOP_PROFILE_SECTION_ENABLED()) {
+    KOKKOS_STOP_PROFILE_SECTION(sec_id);
+  }
+}
+
+extern "C" void kokkosp_destroy_profile_section(const uint32_t sec_id)
+{
+  if (KOKKOS_DESTROY_PROFILE_SECTION_ENABLED()) {
+    KOKKOS_DESTROY_PROFILE_SECTION(sec_id);
+  }
+}
+      
+extern "C" void kokkosp_profile_event(const char* name)
+{
+  if (KOKKOS_PROFILE_EVENT_ENABLED()) {
+    KOKKOS_PROFILE_EVENT(name);
+  }
+}

--- a/src/tools/systemtap-connector/probes.d
+++ b/src/tools/systemtap-connector/probes.d
@@ -1,0 +1,33 @@
+provider kokkos {
+	probe begin_parallel_for(const char*, const uint32_t, uint64_t*);
+	probe begin_parallel_scan(const char*, const uint32_t, uint64_t*);
+	probe begin_parallel_reduce(const char*, const uint32_t, uint64_t*);
+
+	probe end_parallel_scan(uint64_t);
+	probe end_parallel_for(uint64_t);
+	probe end_parallel_reduce(uint64_t);
+
+	probe init_library(const int,
+                           const uint64_t,
+                           const uint32_t,
+                           KokkosPDeviceInfo*);
+	probe finalize_library();
+
+	probe push_profile_region(const char*);
+	probe pop_profile_region();
+
+	probe allocate_data(const SpaceHandle, const char*, const void*, const uint64_t);
+	probe deallocate_data(const SpaceHandle, const char*, const void*, const uint64_t);
+
+	probe begin_deep_copy(SpaceHandle, const char*, const void*,
+	    SpaceHandle, const char*, const void*,
+	    uint64_t);
+	probe end_deep_copy();
+      
+	probe create_profile_section(const char*, uint32_t*);
+	probe start_profile_section(const uint32_t);
+	probe stop_profile_section(const uint32_t);
+	probe destroy_profile_section(const uint32_t);
+      
+	probe profile_event(const char*);
+};


### PR DESCRIPTION
This series of patches provide locations for SystemTap scripts to instrument.  SystemTap allows instrumentation across different layers of software and processes giving a broader view of that happening on the system.  This may be useful in investigating problems caused by unexpected interactions between kernel- and user-space code.