### PR TITLE
kp_kernel_timer: Replace call to get_current_dir_name

### DIFF
--- a/src/tools/simple-kernel-timer/kp_kernel_timer.cpp
+++ b/src/tools/simple-kernel-timer/kp_kernel_timer.cpp
@@ -101,7 +101,9 @@ extern "C" void kokkosp_finalize_library() {
 
 	fclose(output_data);
 
-        printf("KokkosP: Kernel timing written to %s/%s \n", get_current_dir_name(), fileOutput);
+	char* currentwd  = (char*) malloc(sizeof(char) * 256);
+  getcwd(currentwd, 256);
+  printf("KokkosP: Kernel timing written to %s/%s \n", currentwd, fileOutput);
 
 	/*printf("\n");
 	printf("======================================================================\n");

--- a/src/tools/simple-kernel-timer/kp_kernel_timer.cpp
+++ b/src/tools/simple-kernel-timer/kp_kernel_timer.cpp
@@ -101,7 +101,7 @@ extern "C" void kokkosp_finalize_library() {
 
 	fclose(output_data);
 
-	char* currentwd  = (char*) malloc(sizeof(char) * 256);
+	char currentwd[256];
   getcwd(currentwd, 256);
   printf("KokkosP: Kernel timing written to %s/%s \n", currentwd, fileOutput);
 


### PR DESCRIPTION
get_current_dir_name is not portable to some MacOSX systems, leading to
errors when trying to compile the kp_kernel_timer tool like:

error: 'get_current_dir_name' was not declared in this scope

This commit replaces that call with use of getcwd