### PR TITLE
Removed high-level functions that are called implicitly.

### DIFF
--- a/src/tools/papi-connector/kp_papi_connector.cpp
+++ b/src/tools/papi-connector/kp_papi_connector.cpp
@@ -22,7 +22,7 @@ extern "C" void kokkosp_init_library(const int loadSeq,
    printf("KokkosP: PAPI Connector (sequence is %d, version: %llu)\n", loadSeq, interfaceVer);
    printf("-----------------------------------------------------------\n");
 
-   PAPI_hl_init();
+   //PAPI_hl_init();
    /* set default values from kokkos if KOKKOS_PAPI_EVENTS is not set */
    //PAPI_hl_set_events("perf::TASK-CLOCK,PAPI_TOT_INS,PAPI_TOT_CYC,PAPI_FP_OPS");
 }
@@ -30,8 +30,8 @@ extern "C" void kokkosp_init_library(const int loadSeq,
 extern "C" void kokkosp_finalize_library()
 {
 
-   PAPI_hl_print_output();
-   PAPI_hl_finalize();
+   //PAPI_hl_print_output();
+   //PAPI_hl_finalize();
 
    printf("-----------------------------------------------------------\n");
    printf("KokkosP: Finalization of PAPI Connector. Complete.\n");

--- a/src/tools/papi-connector/kp_papi_connector.cpp
+++ b/src/tools/papi-connector/kp_papi_connector.cpp
@@ -22,14 +22,22 @@ extern "C" void kokkosp_init_library(const int loadSeq,
    printf("KokkosP: PAPI Connector (sequence is %d, version: %llu)\n", loadSeq, interfaceVer);
    printf("-----------------------------------------------------------\n");
 
+   /* The following advanced functions of PAPI's high-level API are not part
+    * of the official release. But they might be introduced in later PAPI releases.
+    * PAPI_hl_init is now called from the first PAPI_hl_region_begin call.
+    * /
    //PAPI_hl_init();
-   /* set default values from kokkos if KOKKOS_PAPI_EVENTS is not set */
+   /* set default values */
    //PAPI_hl_set_events("perf::TASK-CLOCK,PAPI_TOT_INS,PAPI_TOT_CYC,PAPI_FP_OPS");
 }
 
 extern "C" void kokkosp_finalize_library()
 {
-
+   /* The following advanced functions of PAPI's high-level API are not part
+    * of the official release. But they might be introduced in later PAPI releases.
+    * PAPI_hl_print_output is registered by the "atexit" function and will be called
+    * at process termination, see http://man7.org/linux/man-pages/man3/atexit.3.html.
+    * /
    //PAPI_hl_print_output();
    //PAPI_hl_finalize();
 


### PR DESCRIPTION
PAPI_hl_init, PAPI_hl_print_output and PAPI_hl_finalize are not part of the official PAPI repo anymore.
I only commented them out since they might come back in later releases.