### PR TITLE
Fixed units for macOS

### DIFF
--- a/src/tools/memory-hwm-mpi/kp_hwm_mpi.cpp
+++ b/src/tools/memory-hwm-mpi/kp_hwm_mpi.cpp
@@ -8,6 +8,13 @@
 static int world_rank = 0;
 static int world_size = 1;
 
+// darwin report rusage.ru_maxrss in bytes
+#if defined(__APPLE__) || defined(__MACH__)
+#    define RU_MAXRSS_UNITS 1024
+#else
+#    define RU_MAXRSS_UNITS 1
+#endif
+
 extern "C" void kokkosp_init_library(const int loadSeq,
   const uint64_t interfaceVer,
   const uint32_t devInfoCount,
@@ -35,7 +42,7 @@ extern "C" void kokkosp_finalize_library() {
 
   struct rusage sys_resources;
   getrusage(RUSAGE_SELF, &sys_resources);
-  long hwm = sys_resources.ru_maxrss;
+  long hwm = sys_resources.ru_maxrss * RU_MAXRSS_UNITS;
 
   // Max
   long hwm_max;

--- a/src/tools/memory-hwm/kp_hwm.cpp
+++ b/src/tools/memory-hwm/kp_hwm.cpp
@@ -23,6 +23,13 @@ extern "C" void kokkosp_init_library(const int loadSeq,
 	printf("KokkosP: Example Library Initialized (sequence is %d, version: %llu)\n", loadSeq, interfaceVer);
 }
 
+// darwin report rusage.ru_maxrss in bytes
+#if defined(__APPLE__) || defined(__MACH__)
+#    define RU_MAXRSS_UNITS 1024
+#else
+#    define RU_MAXRSS_UNITS 1
+#endif
+
 extern "C" void kokkosp_finalize_library() {
 	printf("\n");
 	printf("KokkosP: Finalization of profiling library.\n");
@@ -30,7 +37,7 @@ extern "C" void kokkosp_finalize_library() {
 	struct rusage sys_resources;
 	getrusage(RUSAGE_SELF, &sys_resources);
 
-	printf("KokkosP: High water mark memory consumption: %d kB\n",
-		sys_resources.ru_maxrss);
+	printf("KokkosP: High water mark memory consumption: %li kB\n",
+		(long) sys_resources.ru_maxrss * RU_MAXRSS_UNITS);
 	printf("\n");
 }


### PR DESCRIPTION
- Fixed printf warning in kp_hwm.cpp
- Fixes #36 