### PR TITLE
Prototype Tuning Tool

### DIFF
--- a/include/impl/Kokkos_Profiling_C_Interface.h
+++ b/include/impl/Kokkos_Profiling_C_Interface.h
@@ -77,11 +77,13 @@ struct Kokkos_Tuning_VariableValue {
 
 
 struct Kokkos_Tuning_ValueSet {
-  int size;
+  size_t id;
+  size_t size;
   struct Kokkos_Tuning_VariableValue* values;
 };
 
 struct Kokkos_Tuning_ValueRange {
+  size_t id;
   Kokkos_Tuning_VariableValue lower;
   Kokkos_Tuning_VariableValue upper;
   bool openLower;

--- a/include/impl/Kokkos_Profiling_C_Interface.h
+++ b/include/impl/Kokkos_Profiling_C_Interface.h
@@ -24,10 +24,10 @@
 // contributors may be used to endorse or promote products derived from
 // this software without specific prior written permission.
 //
-// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
 // CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
 // EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
 // PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
@@ -63,93 +63,6 @@ struct Kokkos_Profiling_SpaceHandle {
   char name[64];
 };
 
-struct Kokkos_Tuning_VariableValue;  // forward declaration
-
-struct Kokkos_Tuning_ValueSet {
-  size_t id;
-  size_t size;
-  struct Kokkos_Tuning_VariableValue* values;
-};
-
-enum Kokkos_Tuning_OptimizationType {
-  Kokkos_Tuning_Minimize,
-  Kokkos_Tuning_Maximize
-};
-
-struct Kokkos_Tuning_OptimzationGoal {
-  size_t id;
-  Kokkos_Tuning_OptimizationType goal;
-};
-
-struct Kokkos_Tuning_ValueRange {
-  size_t id;
-  Kokkos_Tuning_VariableValue*
-      lower;  // pointer because I'm used in Kokkos_VariableValue_ValueUnion,
-              // defined below
-  Kokkos_Tuning_VariableValue* upper;
-  Kokkos_Tuning_VariableValue* step;
-  bool openLower;
-  bool openUpper;
-};
-
-union Kokkos_Tuning_VariableValue_ValueUnion {
-  bool bool_value;
-  int64_t int_value;
-  double double_value;
-  const char* string_value;
-  Kokkos_Tuning_ValueRange range_value;
-  Kokkos_Tuning_ValueSet set_value;
-};
-
-struct Kokkos_Tuning_VariableValue {
-  size_t id;
-  union Kokkos_Tuning_VariableValue_ValueUnion value;
-};
-
-enum Kokkos_Tuning_VariableInfo_ValueType {
-  kokkos_value_floating_point,  // TODO DZP: single and double? One or the
-  kokkos_value_integer,
-  kokkos_value_text,
-  kokkos_value_boolean,
-  kokkos_value_floating_point_tuple,
-  kokkos_value_integer_tuple,
-  kokkos_value_text_tuple,
-  kokkos_value_boolean_tuple,
-  kokkos_value_floating_point_range,  // TODO DZP: prove to myself that a
-                                      // boolean or text range is stupid and
-                                      // shouldn't exist
-  kokkos_value_integer_range,
-};
-
-enum Kokkos_Tuning_VariableInfo_StatisticalCategory {
-  kokkos_value_categorical,  // unordered distinct objects
-  kokkos_value_ordinal,      // ordered distinct objects
-  kokkos_value_interval,  // ordered distinct objects for which distance matters
-  kokkos_value_ratio  // ordered distinct objects for which distance matters,
-                      // division matters, and the concept of zero exists
-};
-
-enum Kokkos_Tuning_VariableInfo_CandidateValueType {
-  kokkos_value_set,       // I am one of [2,3,4,5]
-  kokkos_value_range,     // I am somewhere in [2,12)
-  kokkos_value_unbounded  // I am [text/int/float], but we don't know at
-                          // declaration time what values are appropriate. Only
-                          // valid for Context Variables
-  // TODO DZP: not handled: 1 + 3x, sets of ranges, range with hole (zero). Do
-  // these matter?
-};
-
-union Kokkos_Tuning_VariableInfo_SetOrRange {
-  struct Kokkos_Tuning_ValueSet set;
-  struct Kokkos_Tuning_ValueRange range;
-};
-
-struct Kokkos_Tuning_VariableInfo {
-  enum Kokkos_Tuning_VariableInfo_ValueType type;
-  enum Kokkos_Tuning_VariableInfo_StatisticalCategory category;
-  enum Kokkos_Tuning_VariableInfo_CandidateValueType valueQuantity;
-};
-
 typedef void (*Kokkos_Profiling_initFunction)(
     const int, const uint64_t, const uint32_t,
     Kokkos_Profiling_KokkosPDeviceInfo*);
@@ -181,22 +94,26 @@ typedef void (*Kokkos_Profiling_beginDeepCopyFunction)(
     Kokkos_Profiling_SpaceHandle, const char*, const void*, uint64_t);
 typedef void (*Kokkos_Profiling_endDeepCopyFunction)();
 
-typedef void (*Kokkos_Tuning_tuningVariableDeclarationFunction)(
-    const char*, const size_t, Kokkos_Tuning_VariableInfo info);
-typedef void (*Kokkos_Tuning_contextVariableDeclarationFunction)(
-    const char*, const size_t, Kokkos_Tuning_VariableInfo info,
-    Kokkos_Tuning_VariableInfo_SetOrRange);
-
-typedef void (*Kokkos_Tuning_tuningVariableValueFunction)(
-    const size_t, const size_t,
-    const Kokkos_Tuning_VariableValue*, const size_t count,
-    Kokkos_Tuning_VariableValue*,
-    Kokkos_Tuning_VariableInfo_SetOrRange*);
-typedef void (*Kokkos_Tuning_contextVariableValueFunction)(
-    const size_t contextId, const size_t count,
-    Kokkos_Tuning_VariableValue* values);
-typedef void (*Kokkos_Tuning_contextEndFunction)(const size_t);
-typedef void (*Kokkos_Tuning_optimizationGoalDeclarationFunction)(
-    const Kokkos_Tuning_OptimzationGoal& goal);
+struct Kokkos_Profiling_EventSet {
+  Kokkos_Profiling_initFunction init;
+  Kokkos_Profiling_finalizeFunction finalize;
+  Kokkos_Profiling_beginFunction begin_parallel_for;
+  Kokkos_Profiling_endFunction end_parallel_for;
+  Kokkos_Profiling_beginFunction begin_parallel_reduce;
+  Kokkos_Profiling_endFunction end_parallel_reduce;
+  Kokkos_Profiling_beginFunction begin_parallel_scan;
+  Kokkos_Profiling_endFunction end_parallel_scan;
+  Kokkos_Profiling_pushFunction push_region;
+  Kokkos_Profiling_popFunction pop_region;
+  Kokkos_Profiling_allocateDataFunction allocate_data;
+  Kokkos_Profiling_deallocateDataFunction deallocate_data;
+  Kokkos_Profiling_createProfileSectionFunction create_profile_section;
+  Kokkos_Profiling_startProfileSectionFunction start_profile_section;
+  Kokkos_Profiling_stopProfileSectionFunction stop_profile_section;
+  Kokkos_Profiling_destroyProfileSectionFunction destroy_profile_section;
+  Kokkos_Profiling_profileEventFunction profile_event;
+  Kokkos_Profiling_beginDeepCopyFunction begin_deep_copy;
+  Kokkos_Profiling_endDeepCopyFunction end_deep_copy;
+};
 
 #endif  // KOKKOS_PROFILING_C_INTERFACE_HPP

--- a/include/impl/Kokkos_Profiling_C_Interface.h
+++ b/include/impl/Kokkos_Profiling_C_Interface.h
@@ -58,23 +58,11 @@ struct Kokkos_Profiling_KokkosPDeviceInfo {
   size_t deviceID;
 };
 
-
 struct Kokkos_Profiling_SpaceHandle {
   const char* name;
 };
 
-union Kokkos_Tuning_VariableValue_ValueUnion {
-  bool bool_value;
-  int int_value;
-  double double_value;
-  const char* string_value;
-};
-
-struct Kokkos_Tuning_VariableValue {
- size_t id;
- union Kokkos_Tuning_VariableValue_ValueUnion value;
-};
-
+struct Kokkos_Tuning_VariableValue;  // forward declaration
 
 struct Kokkos_Tuning_ValueSet {
   size_t id;
@@ -84,31 +72,60 @@ struct Kokkos_Tuning_ValueSet {
 
 struct Kokkos_Tuning_ValueRange {
   size_t id;
-  Kokkos_Tuning_VariableValue lower;
-  Kokkos_Tuning_VariableValue upper;
+  Kokkos_Tuning_VariableValue*
+      lower;  // pointer because I'm used in Kokkos_VariableValue_ValueUnion,
+              // defined below
+  Kokkos_Tuning_VariableValue* upper;
+  Kokkos_Tuning_VariableValue* step;
   bool openLower;
   bool openUpper;
 };
 
+union Kokkos_Tuning_VariableValue_ValueUnion {
+  bool bool_value;
+  int int_value;
+  double double_value;
+  const char* string_value;
+  Kokkos_Tuning_ValueRange range_value;
+  Kokkos_Tuning_ValueSet set_value;
+};
+
+struct Kokkos_Tuning_VariableValue {
+  size_t id;
+  union Kokkos_Tuning_VariableValue_ValueUnion value;
+};
+
 enum Kokkos_Tuning_VariableInfo_ValueType {
-    kokkos_value_floating_point, // TODO DZP: single and double? One or the other?
-    kokkos_value_integer,
-    kokkos_value_text,
-    kokkos_value_boolean
+  kokkos_value_floating_point,  // TODO DZP: single and double? One or the
+  kokkos_value_integer,
+  kokkos_value_text,
+  kokkos_value_boolean,
+  kokkos_value_floating_point_tuple,
+  kokkos_value_integer_tuple,
+  kokkos_value_text_tuple,
+  kokkos_value_boolean_tuple,
+  kokkos_value_floating_point_range,  // TODO DZP: prove to myself that a
+                                      // boolean or text range is stupid and
+                                      // shouldn't exist
+  kokkos_value_integer_range,
 };
 
 enum Kokkos_Tuning_VariableInfo_StatisticalCategory {
-  kokkos_value_categorical, // unordered distinct objects
-  kokkos_value_ordinal,     // ordered distinct objects
-  kokkos_value_interval,    // ordered distinct objects for which distance matters
-  kokkos_value_ratio        // ordered distinct objects for which distance matters, division matters, and the concept of zero exists
+  kokkos_value_categorical,  // unordered distinct objects
+  kokkos_value_ordinal,      // ordered distinct objects
+  kokkos_value_interval,  // ordered distinct objects for which distance matters
+  kokkos_value_ratio  // ordered distinct objects for which distance matters,
+                      // division matters, and the concept of zero exists
 };
 
 enum Kokkos_Tuning_VariableInfo_CandidateValueType {
-  kokkos_value_set,        // I am one of [2,3,4,5]
-  kokkos_value_range,      // I am somewhere in [2,12)
-  kokkos_value_unbounded   // I am [text/int/float], but we don't know at declaration time what values are appropriate. Only valid for Context Variables
-  // TODO DZP: not handled: 1 + 3x, sets of ranges, range with hole (zero). Do these matter?
+  kokkos_value_set,       // I am one of [2,3,4,5]
+  kokkos_value_range,     // I am somewhere in [2,12)
+  kokkos_value_unbounded  // I am [text/int/float], but we don't know at
+                          // declaration time what values are appropriate. Only
+                          // valid for Context Variables
+  // TODO DZP: not handled: 1 + 3x, sets of ranges, range with hole (zero). Do
+  // these matter?
 };
 
 union Kokkos_Tuning_VariableInfo_SetOrRange {
@@ -122,37 +139,50 @@ struct Kokkos_Tuning_VariableInfo {
   enum Kokkos_Tuning_VariableInfo_CandidateValueType valueQuantity;
 };
 
-typedef void (*Kokkos_Profiling_initFunction)(const int, const uint64_t, const uint32_t,
-                            Kokkos_Profiling_KokkosPDeviceInfo*);
+typedef void (*Kokkos_Profiling_initFunction)(
+    const int, const uint64_t, const uint32_t,
+    Kokkos_Profiling_KokkosPDeviceInfo*);
 typedef void (*Kokkos_Profiling_finalizeFunction)();
-typedef void (*Kokkos_Profiling_beginFunction)(const char*, const uint32_t, uint64_t*);
+typedef void (*Kokkos_Profiling_beginFunction)(const char*, const uint32_t,
+                                               uint64_t*);
 typedef void (*Kokkos_Profiling_endFunction)(uint64_t);
 
 typedef void (*Kokkos_Profiling_pushFunction)(const char*);
 typedef void (*Kokkos_Profiling_popFunction)();
 
-typedef void (*Kokkos_Profiling_allocateDataFunction)(const Kokkos_Profiling_SpaceHandle, const char*,
-                                     const void*, const uint64_t);
-typedef void (*Kokkos_Profiling_deallocateDataFunction)(const Kokkos_Profiling_SpaceHandle, const char*,
-                                       const void*, const uint64_t);
+typedef void (*Kokkos_Profiling_allocateDataFunction)(
+    const Kokkos_Profiling_SpaceHandle, const char*, const void*,
+    const uint64_t);
+typedef void (*Kokkos_Profiling_deallocateDataFunction)(
+    const Kokkos_Profiling_SpaceHandle, const char*, const void*,
+    const uint64_t);
 
-typedef void (*Kokkos_Profiling_createProfileSectionFunction)(const char*, uint32_t*);
+typedef void (*Kokkos_Profiling_createProfileSectionFunction)(const char*,
+                                                              uint32_t*);
 typedef void (*Kokkos_Profiling_startProfileSectionFunction)(const uint32_t);
 typedef void (*Kokkos_Profiling_stopProfileSectionFunction)(const uint32_t);
 typedef void (*Kokkos_Profiling_destroyProfileSectionFunction)(const uint32_t);
 
 typedef void (*Kokkos_Profiling_profileEventFunction)(const char*);
 
-typedef void (*Kokkos_Profiling_beginDeepCopyFunction)(Kokkos_Profiling_SpaceHandle, const char*, const void*,
-                                      Kokkos_Profiling_SpaceHandle, const char*, const void*,
-                                      uint64_t);
+typedef void (*Kokkos_Profiling_beginDeepCopyFunction)(
+    Kokkos_Profiling_SpaceHandle, const char*, const void*,
+    Kokkos_Profiling_SpaceHandle, const char*, const void*, uint64_t);
 typedef void (*Kokkos_Profiling_endDeepCopyFunction)();
 
-typedef void (*Kokkos_Tuning_tuningVariableDeclarationFunction)(const char*, const size_t, Kokkos_Tuning_VariableInfo info); 
-typedef void (*Kokkos_Tuning_contextVariableDeclarationFunction)(const char*, const size_t, Kokkos_Tuning_VariableInfo info, Kokkos_Tuning_VariableInfo_SetOrRange); 
-typedef void (*Kokkos_Tuning_tuningVariableValueFunction)(const size_t, const size_t, const size_t*, const Kokkos_Tuning_VariableValue*, const size_t count, const size_t* uniqIds, Kokkos_Tuning_VariableValue*, Kokkos_Tuning_VariableInfo_SetOrRange*);
-typedef void (*Kokkos_Tuning_contextVariableValueFunction)(const size_t contextId, const size_t count, const size_t* uniqIds, Kokkos_Tuning_VariableValue* values);
+typedef void (*Kokkos_Tuning_tuningVariableDeclarationFunction)(
+    const char*, const size_t, Kokkos_Tuning_VariableInfo info);
+typedef void (*Kokkos_Tuning_contextVariableDeclarationFunction)(
+    const char*, const size_t, Kokkos_Tuning_VariableInfo info,
+    Kokkos_Tuning_VariableInfo_SetOrRange);
+typedef void (*Kokkos_Tuning_tuningVariableValueFunction)(
+    const size_t, const size_t, const size_t*,
+    const Kokkos_Tuning_VariableValue*, const size_t count,
+    const size_t* uniqIds, Kokkos_Tuning_VariableValue*,
+    Kokkos_Tuning_VariableInfo_SetOrRange*);
+typedef void (*Kokkos_Tuning_contextVariableValueFunction)(
+    const size_t contextId, const size_t count, const size_t* uniqIds,
+    Kokkos_Tuning_VariableValue* values);
 typedef void (*Kokkos_Tuning_contextEndFunction)(const size_t);
 
-
-#endif // KOKKOS_PROFILING_C_INTERFACE_HPP
+#endif  // KOKKOS_PROFILING_C_INTERFACE_HPP

--- a/include/impl/Kokkos_Profiling_C_Interface.h
+++ b/include/impl/Kokkos_Profiling_C_Interface.h
@@ -1,45 +1,46 @@
 /*
- //@HEADER
- // ************************************************************************
- //
- //                        Kokkos v. 2.0
- //              Copyright (2014) Sandia Corporation
- //
- // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
- // the U.S. Government retains certain rights in this software.
- //
- // Redistribution and use in source and binary forms, with or without
- // modification, are permitted provided that the following conditions are
- // met:
- //
- // 1. Redistributions of source code must retain the above copyright
- // notice, this list of conditions and the following disclaimer.
- //
- // 2. Redistributions in binary form must reproduce the above copyright
- // notice, this list of conditions and the following disclaimer in the
- // documentation and/or other materials provided with the distribution.
- //
- // 3. Neither the name of the Corporation nor the names of the
- // contributors may be used to endorse or promote products derived from
- // this software without specific prior written permission.
- //
- // THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
- // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- // PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
- // CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- // EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- // PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- // PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
- // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- //
- // Questions? Contact Christian R. Trott (crtrott@sandia.gov)
- //
- // ************************************************************************
- //@HEADER
- */
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
 
 #ifndef KOKKOS_PROFILING_C_INTERFACE_HPP
 #define KOKKOS_PROFILING_C_INTERFACE_HPP
@@ -59,7 +60,7 @@ struct Kokkos_Profiling_KokkosPDeviceInfo {
 };
 
 struct Kokkos_Profiling_SpaceHandle {
-  const char* name;
+  char name[64];
 };
 
 struct Kokkos_Tuning_VariableValue;  // forward declaration
@@ -68,6 +69,16 @@ struct Kokkos_Tuning_ValueSet {
   size_t id;
   size_t size;
   struct Kokkos_Tuning_VariableValue* values;
+};
+
+enum Kokkos_Tuning_OptimizationType {
+  Kokkos_Tuning_Minimize,
+  Kokkos_Tuning_Maximize
+};
+
+struct Kokkos_Tuning_OptimzationGoal {
+  size_t id;
+  Kokkos_Tuning_OptimizationType goal;
 };
 
 struct Kokkos_Tuning_ValueRange {
@@ -83,7 +94,7 @@ struct Kokkos_Tuning_ValueRange {
 
 union Kokkos_Tuning_VariableValue_ValueUnion {
   bool bool_value;
-  int int_value;
+  int64_t int_value;
   double double_value;
   const char* string_value;
   Kokkos_Tuning_ValueRange range_value;
@@ -175,14 +186,17 @@ typedef void (*Kokkos_Tuning_tuningVariableDeclarationFunction)(
 typedef void (*Kokkos_Tuning_contextVariableDeclarationFunction)(
     const char*, const size_t, Kokkos_Tuning_VariableInfo info,
     Kokkos_Tuning_VariableInfo_SetOrRange);
+
 typedef void (*Kokkos_Tuning_tuningVariableValueFunction)(
-    const size_t, const size_t, const size_t*,
+    const size_t, const size_t,
     const Kokkos_Tuning_VariableValue*, const size_t count,
-    const size_t* uniqIds, Kokkos_Tuning_VariableValue*,
+    Kokkos_Tuning_VariableValue*,
     Kokkos_Tuning_VariableInfo_SetOrRange*);
 typedef void (*Kokkos_Tuning_contextVariableValueFunction)(
-    const size_t contextId, const size_t count, const size_t* uniqIds,
+    const size_t contextId, const size_t count,
     Kokkos_Tuning_VariableValue* values);
 typedef void (*Kokkos_Tuning_contextEndFunction)(const size_t);
+typedef void (*Kokkos_Tuning_optimizationGoalDeclarationFunction)(
+    const Kokkos_Tuning_OptimzationGoal& goal);
 
 #endif  // KOKKOS_PROFILING_C_INTERFACE_HPP

--- a/include/impl/Kokkos_Profiling_C_Interface.h
+++ b/include/impl/Kokkos_Profiling_C_Interface.h
@@ -1,0 +1,156 @@
+/*
+ //@HEADER
+ // ************************************************************************
+ //
+ //                        Kokkos v. 2.0
+ //              Copyright (2014) Sandia Corporation
+ //
+ // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+ // the U.S. Government retains certain rights in this software.
+ //
+ // Redistribution and use in source and binary forms, with or without
+ // modification, are permitted provided that the following conditions are
+ // met:
+ //
+ // 1. Redistributions of source code must retain the above copyright
+ // notice, this list of conditions and the following disclaimer.
+ //
+ // 2. Redistributions in binary form must reproduce the above copyright
+ // notice, this list of conditions and the following disclaimer in the
+ // documentation and/or other materials provided with the distribution.
+ //
+ // 3. Neither the name of the Corporation nor the names of the
+ // contributors may be used to endorse or promote products derived from
+ // this software without specific prior written permission.
+ //
+ // THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+ // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ // PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+ // CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ // EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ // PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ // PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ //
+ // Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+ //
+ // ************************************************************************
+ //@HEADER
+ */
+
+#ifndef KOKKOS_PROFILING_C_INTERFACE_HPP
+#define KOKKOS_PROFILING_C_INTERFACE_HPP
+
+#ifdef __cplusplus
+#include <cstddef>
+#include <cstdint>
+#else
+#include <stddef.h>
+#include <stdint.h>
+#endif
+
+#define KOKKOSP_INTERFACE_VERSION 20191080
+
+struct Kokkos_Profiling_KokkosPDeviceInfo {
+  size_t deviceID;
+};
+
+
+struct Kokkos_Profiling_SpaceHandle {
+  const char* name;
+};
+
+union Kokkos_Tuning_VariableValue_ValueUnion {
+  bool bool_value;
+  int int_value;
+  double double_value;
+  const char* string_value;
+};
+
+struct Kokkos_Tuning_VariableValue {
+ size_t id;
+ union Kokkos_Tuning_VariableValue_ValueUnion value;
+};
+
+
+struct Kokkos_Tuning_ValueSet {
+  int size;
+  struct Kokkos_Tuning_VariableValue* values;
+};
+
+struct Kokkos_Tuning_ValueRange {
+  Kokkos_Tuning_VariableValue lower;
+  Kokkos_Tuning_VariableValue upper;
+  bool openLower;
+  bool openUpper;
+};
+
+enum Kokkos_Tuning_VariableInfo_ValueType {
+    kokkos_value_floating_point, // TODO DZP: single and double? One or the other?
+    kokkos_value_integer,
+    kokkos_value_text,
+    kokkos_value_boolean
+};
+
+enum Kokkos_Tuning_VariableInfo_StatisticalCategory {
+  kokkos_value_categorical, // unordered distinct objects
+  kokkos_value_ordinal,     // ordered distinct objects
+  kokkos_value_interval,    // ordered distinct objects for which distance matters
+  kokkos_value_ratio        // ordered distinct objects for which distance matters, division matters, and the concept of zero exists
+};
+
+enum Kokkos_Tuning_VariableInfo_CandidateValueType {
+  kokkos_value_set,        // I am one of [2,3,4,5]
+  kokkos_value_range,      // I am somewhere in [2,12)
+  kokkos_value_unbounded   // I am [text/int/float], but we don't know at declaration time what values are appropriate. Only valid for Context Variables
+  // TODO DZP: not handled: 1 + 3x, sets of ranges, range with hole (zero). Do these matter?
+};
+
+union Kokkos_Tuning_VariableInfo_SetOrRange {
+  struct Kokkos_Tuning_ValueSet set;
+  struct Kokkos_Tuning_ValueRange range;
+};
+
+struct Kokkos_Tuning_VariableInfo {
+  enum Kokkos_Tuning_VariableInfo_ValueType type;
+  enum Kokkos_Tuning_VariableInfo_StatisticalCategory category;
+  enum Kokkos_Tuning_VariableInfo_CandidateValueType valueQuantity;
+};
+
+typedef void (*Kokkos_Profiling_initFunction)(const int, const uint64_t, const uint32_t,
+                            Kokkos_Profiling_KokkosPDeviceInfo*);
+typedef void (*Kokkos_Profiling_finalizeFunction)();
+typedef void (*Kokkos_Profiling_beginFunction)(const char*, const uint32_t, uint64_t*);
+typedef void (*Kokkos_Profiling_endFunction)(uint64_t);
+
+typedef void (*Kokkos_Profiling_pushFunction)(const char*);
+typedef void (*Kokkos_Profiling_popFunction)();
+
+typedef void (*Kokkos_Profiling_allocateDataFunction)(const Kokkos_Profiling_SpaceHandle, const char*,
+                                     const void*, const uint64_t);
+typedef void (*Kokkos_Profiling_deallocateDataFunction)(const Kokkos_Profiling_SpaceHandle, const char*,
+                                       const void*, const uint64_t);
+
+typedef void (*Kokkos_Profiling_createProfileSectionFunction)(const char*, uint32_t*);
+typedef void (*Kokkos_Profiling_startProfileSectionFunction)(const uint32_t);
+typedef void (*Kokkos_Profiling_stopProfileSectionFunction)(const uint32_t);
+typedef void (*Kokkos_Profiling_destroyProfileSectionFunction)(const uint32_t);
+
+typedef void (*Kokkos_Profiling_profileEventFunction)(const char*);
+
+typedef void (*Kokkos_Profiling_beginDeepCopyFunction)(Kokkos_Profiling_SpaceHandle, const char*, const void*,
+                                      Kokkos_Profiling_SpaceHandle, const char*, const void*,
+                                      uint64_t);
+typedef void (*Kokkos_Profiling_endDeepCopyFunction)();
+
+typedef void (*Kokkos_Tuning_tuningVariableDeclarationFunction)(const char*, const size_t, Kokkos_Tuning_VariableInfo info); 
+typedef void (*Kokkos_Tuning_contextVariableDeclarationFunction)(const char*, const size_t, Kokkos_Tuning_VariableInfo info, Kokkos_Tuning_VariableInfo_SetOrRange); 
+typedef void (*Kokkos_Tuning_tuningVariableValueFunction)(const size_t, const size_t, const size_t*, const Kokkos_Tuning_VariableValue*, const size_t count, const size_t* uniqIds, Kokkos_Tuning_VariableValue*, Kokkos_Tuning_VariableInfo_SetOrRange*);
+typedef void (*Kokkos_Tuning_contextVariableValueFunction)(const size_t contextId, const size_t count, const size_t* uniqIds, Kokkos_Tuning_VariableValue* values);
+typedef void (*Kokkos_Tuning_contextEndFunction)(const size_t);
+
+
+#endif // KOKKOS_PROFILING_C_INTERFACE_HPP

--- a/include/impl/Kokkos_Profiling_DeviceInfo.hpp
+++ b/include/impl/Kokkos_Profiling_DeviceInfo.hpp
@@ -2,10 +2,11 @@
  //@HEADER
  // ************************************************************************
  //
- //                        Kokkos v. 2.0
- //              Copyright (2014) Sandia Corporation
+ //                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
  //
- // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+ // Under the terms of Contract DE-NA0003525 with NTESS,
  // the U.S. Government retains certain rights in this software.
  //
  // Redistribution and use in source and binary forms, with or without

--- a/include/impl/Kokkos_Profiling_DeviceInfo.hpp
+++ b/include/impl/Kokkos_Profiling_DeviceInfo.hpp
@@ -1,0 +1,55 @@
+/*
+ //@HEADER
+ // ************************************************************************
+ //
+ //                        Kokkos v. 2.0
+ //              Copyright (2014) Sandia Corporation
+ //
+ // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+ // the U.S. Government retains certain rights in this software.
+ //
+ // Redistribution and use in source and binary forms, with or without
+ // modification, are permitted provided that the following conditions are
+ // met:
+ //
+ // 1. Redistributions of source code must retain the above copyright
+ // notice, this list of conditions and the following disclaimer.
+ //
+ // 2. Redistributions in binary form must reproduce the above copyright
+ // notice, this list of conditions and the following disclaimer in the
+ // documentation and/or other materials provided with the distribution.
+ //
+ // 3. Neither the name of the Corporation nor the names of the
+ // contributors may be used to endorse or promote products derived from
+ // this software without specific prior written permission.
+ //
+ // THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+ // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ // PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+ // CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ // EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ // PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ // PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ //
+ // Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+ //
+ // ************************************************************************
+ //@HEADER
+*/
+
+#ifndef KOKKOSP_DEVICE_INFO_HPP
+#define KOKKOSP_DEVICE_INFO_HPP
+
+#include <cstdint>
+#include <impl/Kokkos_Profiling_C_Interface.h>
+namespace Kokkos {
+namespace Profiling {
+using KokkosPDeviceInfo = Kokkos_Profiling_KokkosPDeviceInfo;
+}  // namespace Profiling
+}  // namespace Kokkos
+
+#endif

--- a/include/impl/Kokkos_Profiling_Interface.hpp
+++ b/include/impl/Kokkos_Profiling_Interface.hpp
@@ -55,8 +55,7 @@
 #include <impl/Kokkos_Profiling_DeviceInfo.hpp>
 #include <impl/Kokkos_Profiling_C_Interface.h>
 #include <impl/Kokkos_Profiling_C_Interface.h>
-#define KOKKOS_ENABLE_TUNING  // TODO DZP: this needs to be a proper build
-                              // system option
+
 namespace Kokkos {
 namespace Profiling {
 
@@ -120,59 +119,4 @@ using contextEndFunction           = Kokkos_Tuning_contextEndFunction;
 
 }  // namespace Kokkos
 
-#if 0  // TODO DZP: reimplement or set on fire
-namespace Kokkos {
-namespace Profiling {
-
-struct SpaceHandle {
-  SpaceHandle(const char* space_name);
-  char name[64];
-};
-
-bool profileLibraryLoaded();
-
-void beginParallelFor(const std::string&, const uint32_t, uint64_t*);
-void endParallelFor(const uint64_t);
-void beginParallelScan(const std::string&, const uint32_t, uint64_t*);
-void endParallelScan(const uint64_t);
-void beginParallelReduce(const std::string&, const uint32_t, uint64_t*);
-void endParallelReduce(const uint64_t);
-
-void pushRegion(const std::string&);
-void popRegion();
-void createProfileSection(const std::string&, uint32_t*);
-void startSection(const uint32_t);
-void stopSection(const uint32_t);
-void destroyProfileSection(const uint32_t);
-
-void markEvent(const std::string&);
-
-void allocateData(const SpaceHandle, const std::string, const void*,
-                  const uint64_t);
-void deallocateData(const SpaceHandle, const std::string, const void*,
-                    const uint64_t);
-
-void beginDeepCopy(const SpaceHandle, const std::string, const void*,
-                   const SpaceHandle, const std::string, const void*,
-                   const uint64_t);
-void endDeepCopy();
-
-void initialize();
-void finalize();
-
-} // end namespace Profiling
-namespace Tuning  {
-void declareTuningVariable(const std::string& variableName, int uniqID, VariableInfo info); 
-
-void declareContextVariable(const std::string& variableName, int uniqID, VariableInfo info); 
-
-void declareContextVariableValues(int contextId, int count, int* uniqIds, VariableValue* values);
-
-void endContext(int contextId);
-
-void requestTuningVariableValues(int count, int* uniqIds, VariableValue* values);
-
-} // end namespace Tuning
-} // end namespace Kokkos
-#endif
 #endif

--- a/include/impl/Kokkos_Profiling_Interface.hpp
+++ b/include/impl/Kokkos_Profiling_Interface.hpp
@@ -2,10 +2,11 @@
  //@HEADER
  // ************************************************************************
  //
- //                        Kokkos v. 2.0
- //              Copyright (2014) Sandia Corporation
+ //                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
  //
- // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+ // Under the terms of Contract DE-NA0003525 with NTESS,
  // the U.S. Government retains certain rights in this software.
  //
  // Redistribution and use in source and binary forms, with or without
@@ -72,6 +73,7 @@ using ValueType           = Kokkos_Tuning_VariableInfo_ValueType;
 using CandidateValueType  = Kokkos_Tuning_VariableInfo_CandidateValueType;
 using SetOrRange          = Kokkos_Tuning_VariableInfo_SetOrRange;
 using VariableInfo        = Kokkos_Tuning_VariableInfo;
+using OptimizationGoal    = Kokkos_Tuning_OptimzationGoal;
 // TODO DZP: VariableInfo subclasses to automate some of this
 
 using VariableValue = Kokkos_Tuning_VariableValue;
@@ -114,6 +116,8 @@ using contextVariableDeclarationFunction =
 using tuningVariableValueFunction  = Kokkos_Tuning_tuningVariableValueFunction;
 using contextVariableValueFunction = Kokkos_Tuning_contextVariableValueFunction;
 using contextEndFunction           = Kokkos_Tuning_contextEndFunction;
+using optimizationGoalDeclarationFunction =
+    Kokkos_Tuning_optimizationGoalDeclarationFunction;
 
 }  // end namespace Tuning
 

--- a/include/impl/Kokkos_Profiling_Interface.hpp
+++ b/include/impl/Kokkos_Profiling_Interface.hpp
@@ -1,0 +1,178 @@
+/*
+ //@HEADER
+ // ************************************************************************
+ //
+ //                        Kokkos v. 2.0
+ //              Copyright (2014) Sandia Corporation
+ //
+ // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+ // the U.S. Government retains certain rights in this software.
+ //
+ // Redistribution and use in source and binary forms, with or without
+ // modification, are permitted provided that the following conditions are
+ // met:
+ //
+ // 1. Redistributions of source code must retain the above copyright
+ // notice, this list of conditions and the following disclaimer.
+ //
+ // 2. Redistributions in binary form must reproduce the above copyright
+ // notice, this list of conditions and the following disclaimer in the
+ // documentation and/or other materials provided with the distribution.
+ //
+ // 3. Neither the name of the Corporation nor the names of the
+ // contributors may be used to endorse or promote products derived from
+ // this software without specific prior written permission.
+ //
+ // THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+ // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ // PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+ // CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ // EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ // PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ // PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ //
+ // Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+ //
+ // ************************************************************************
+ //@HEADER
+ */
+
+#ifndef KOKKOSP_INTERFACE_HPP
+#define KOKKOSP_INTERFACE_HPP
+
+#include <cinttypes>
+#include <cstddef>
+#include <string>
+
+#include <iostream>
+#include <cstdlib>
+
+#include <impl/Kokkos_Profiling_DeviceInfo.hpp>
+#include <impl/Kokkos_Profiling_DeviceInfo.hpp>
+#include <impl/Kokkos_Profiling_C_Interface.h>
+#include <impl/Kokkos_Profiling_C_Interface.h>
+#define KOKKOS_ENABLE_TUNING  // TODO DZP: this needs to be a proper build
+                              // system option
+namespace Kokkos {
+namespace Profiling {
+
+using SpaceHandle = Kokkos_Profiling_SpaceHandle;
+
+}  // end namespace Profiling
+
+namespace Tuning {
+
+using ValueSet            = Kokkos_Tuning_ValueSet;
+using ValueRange          = Kokkos_Tuning_ValueRange;
+using StatisticalCategory = Kokkos_Tuning_VariableInfo_StatisticalCategory;
+using ValueType           = Kokkos_Tuning_VariableInfo_ValueType;
+using CandidateValueType  = Kokkos_Tuning_VariableInfo_CandidateValueType;
+using SetOrRange          = Kokkos_Tuning_VariableInfo_SetOrRange;
+using VariableInfo        = Kokkos_Tuning_VariableInfo;
+// TODO DZP: VariableInfo subclasses to automate some of this
+
+using VariableValue = Kokkos_Tuning_VariableValue;
+
+VariableValue make_variable_value(size_t id, bool val);
+VariableValue make_variable_value(size_t id, int val);
+VariableValue make_variable_value(size_t id, double val);
+VariableValue make_variable_value(size_t id, const char* val);
+
+}  // end namespace Tuning
+
+namespace Profiling {
+
+using initFunction           = Kokkos_Profiling_initFunction;
+using finalizeFunction       = Kokkos_Profiling_finalizeFunction;
+using beginFunction          = Kokkos_Profiling_beginFunction;
+using endFunction            = Kokkos_Profiling_endFunction;
+using pushFunction           = Kokkos_Profiling_pushFunction;
+using popFunction            = Kokkos_Profiling_popFunction;
+using allocateDataFunction   = Kokkos_Profiling_allocateDataFunction;
+using deallocateDataFunction = Kokkos_Profiling_deallocateDataFunction;
+using createProfileSectionFunction =
+    Kokkos_Profiling_createProfileSectionFunction;
+using startProfileSectionFunction =
+    Kokkos_Profiling_startProfileSectionFunction;
+using stopProfileSectionFunction = Kokkos_Profiling_stopProfileSectionFunction;
+using destroyProfileSectionFunction =
+    Kokkos_Profiling_destroyProfileSectionFunction;
+using profileEventFunction  = Kokkos_Profiling_profileEventFunction;
+using beginDeepCopyFunction = Kokkos_Profiling_beginDeepCopyFunction;
+using endDeepCopyFunction   = Kokkos_Profiling_endDeepCopyFunction;
+
+}  // end namespace Profiling
+
+namespace Tuning {
+using tuningVariableDeclarationFunction =
+    Kokkos_Tuning_tuningVariableDeclarationFunction;
+using contextVariableDeclarationFunction =
+    Kokkos_Tuning_contextVariableDeclarationFunction;
+using tuningVariableValueFunction  = Kokkos_Tuning_tuningVariableValueFunction;
+using contextVariableValueFunction = Kokkos_Tuning_contextVariableValueFunction;
+using contextEndFunction           = Kokkos_Tuning_contextEndFunction;
+
+}  // end namespace Tuning
+
+}  // namespace Kokkos
+
+#if 0  // TODO DZP: reimplement or set on fire
+namespace Kokkos {
+namespace Profiling {
+
+struct SpaceHandle {
+  SpaceHandle(const char* space_name);
+  char name[64];
+};
+
+bool profileLibraryLoaded();
+
+void beginParallelFor(const std::string&, const uint32_t, uint64_t*);
+void endParallelFor(const uint64_t);
+void beginParallelScan(const std::string&, const uint32_t, uint64_t*);
+void endParallelScan(const uint64_t);
+void beginParallelReduce(const std::string&, const uint32_t, uint64_t*);
+void endParallelReduce(const uint64_t);
+
+void pushRegion(const std::string&);
+void popRegion();
+void createProfileSection(const std::string&, uint32_t*);
+void startSection(const uint32_t);
+void stopSection(const uint32_t);
+void destroyProfileSection(const uint32_t);
+
+void markEvent(const std::string&);
+
+void allocateData(const SpaceHandle, const std::string, const void*,
+                  const uint64_t);
+void deallocateData(const SpaceHandle, const std::string, const void*,
+                    const uint64_t);
+
+void beginDeepCopy(const SpaceHandle, const std::string, const void*,
+                   const SpaceHandle, const std::string, const void*,
+                   const uint64_t);
+void endDeepCopy();
+
+void initialize();
+void finalize();
+
+} // end namespace Profiling
+namespace Tuning  {
+void declareTuningVariable(const std::string& variableName, int uniqID, VariableInfo info); 
+
+void declareContextVariable(const std::string& variableName, int uniqID, VariableInfo info); 
+
+void declareContextVariableValues(int contextId, int count, int* uniqIds, VariableValue* values);
+
+void endContext(int contextId);
+
+void requestTuningVariableValues(int count, int* uniqIds, VariableValue* values);
+
+} // end namespace Tuning
+} // end namespace Kokkos
+#endif
+#endif

--- a/include/impl/Kokkos_Profiling_Interface.hpp
+++ b/include/impl/Kokkos_Profiling_Interface.hpp
@@ -79,7 +79,7 @@ using OptimizationGoal    = Kokkos_Tuning_OptimzationGoal;
 using VariableValue = Kokkos_Tuning_VariableValue;
 
 VariableValue make_variable_value(size_t id, bool val);
-VariableValue make_variable_value(size_t id, int val);
+VariableValue make_variable_value(size_t id, int64_t val);
 VariableValue make_variable_value(size_t id, double val);
 VariableValue make_variable_value(size_t id, const char* val);
 

--- a/include/impl/Kokkos_Tuning_C_Interface.h
+++ b/include/impl/Kokkos_Tuning_C_Interface.h
@@ -1,0 +1,161 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_TUNING_C_INTERFACE_HPP
+#define KOKKOS_TUNING_C_INTERFACE_HPP
+
+#ifdef __cplusplus
+#include <cstddef>
+#include <cstdint>
+#else
+#include <stddef.h>
+#include <stdint.h>
+#endif
+
+struct Kokkos_Tuning_VariableValue;  // forward declaration
+
+struct Kokkos_Tuning_ValueSet {
+  size_t id;
+  size_t size;
+  struct Kokkos_Tuning_VariableValue* values;
+};
+
+enum Kokkos_Tuning_OptimizationType {
+  Kokkos_Tuning_Minimize,
+  Kokkos_Tuning_Maximize
+};
+
+struct Kokkos_Tuning_OptimzationGoal {
+  size_t id;
+  Kokkos_Tuning_OptimizationType goal;
+};
+
+struct Kokkos_Tuning_ValueRange {
+  size_t id;
+  Kokkos_Tuning_VariableValue*
+      lower;  // pointer because I'm used in Kokkos_VariableValue_ValueUnion,
+              // defined below
+  Kokkos_Tuning_VariableValue* upper;
+  Kokkos_Tuning_VariableValue* step;
+  bool openLower;
+  bool openUpper;
+};
+
+union Kokkos_Tuning_VariableValue_ValueUnion {
+  bool bool_value;
+  int64_t int_value;
+  double double_value;
+  const char* string_value;
+  Kokkos_Tuning_ValueRange range_value;
+  Kokkos_Tuning_ValueSet set_value;
+};
+
+struct Kokkos_Tuning_VariableValue {
+  size_t id;
+  union Kokkos_Tuning_VariableValue_ValueUnion value;
+};
+
+enum Kokkos_Tuning_VariableInfo_ValueType {
+  kokkos_value_floating_point,  // TODO DZP: single and double? One or the
+  kokkos_value_integer,
+  kokkos_value_text,
+  kokkos_value_boolean,
+  kokkos_value_floating_point_tuple,
+  kokkos_value_integer_tuple,
+  kokkos_value_text_tuple,
+  kokkos_value_boolean_tuple,
+  kokkos_value_floating_point_range,  // TODO DZP: prove to myself that a
+                                      // boolean or text range is stupid and
+                                      // shouldn't exist
+  kokkos_value_integer_range,
+};
+
+enum Kokkos_Tuning_VariableInfo_StatisticalCategory {
+  kokkos_value_categorical,  // unordered distinct objects
+  kokkos_value_ordinal,      // ordered distinct objects
+  kokkos_value_interval,  // ordered distinct objects for which distance matters
+  kokkos_value_ratio  // ordered distinct objects for which distance matters,
+                      // division matters, and the concept of zero exists
+};
+
+enum Kokkos_Tuning_VariableInfo_CandidateValueType {
+  kokkos_value_set,       // I am one of [2,3,4,5]
+  kokkos_value_range,     // I am somewhere in [2,12)
+  kokkos_value_unbounded  // I am [text/int/float], but we don't know at
+                          // declaration time what values are appropriate. Only
+                          // valid for Context Variables
+  // TODO DZP: not handled: 1 + 3x, sets of ranges, range with hole (zero). Do
+  // these matter?
+};
+
+union Kokkos_Tuning_VariableInfo_SetOrRange {
+  struct Kokkos_Tuning_ValueSet set;
+  struct Kokkos_Tuning_ValueRange range;
+};
+
+struct Kokkos_Tuning_VariableInfo {
+  enum Kokkos_Tuning_VariableInfo_ValueType type;
+  enum Kokkos_Tuning_VariableInfo_StatisticalCategory category;
+  enum Kokkos_Tuning_VariableInfo_CandidateValueType valueQuantity;
+};
+
+typedef void (*Kokkos_Tuning_tuningVariableDeclarationFunction)(
+    const char*, const size_t, Kokkos_Tuning_VariableInfo info);
+typedef void (*Kokkos_Tuning_contextVariableDeclarationFunction)(
+    const char*, const size_t, Kokkos_Tuning_VariableInfo info,
+    Kokkos_Tuning_VariableInfo_SetOrRange);
+
+typedef void (*Kokkos_Tuning_tuningVariableValueFunction)(
+    const size_t, const size_t,
+    const Kokkos_Tuning_VariableValue*, const size_t count,
+    Kokkos_Tuning_VariableValue*,
+    Kokkos_Tuning_VariableInfo_SetOrRange*);
+typedef void (*Kokkos_Tuning_contextVariableValueFunction)(
+    const size_t contextId, const size_t count,
+    Kokkos_Tuning_VariableValue* values);
+typedef void (*Kokkos_Tuning_contextEndFunction)(const size_t);
+typedef void (*Kokkos_Tuning_optimizationGoalDeclarationFunction)(
+    const Kokkos_Tuning_OptimzationGoal& goal);
+
+#endif // KOKKOS_TUNING_C_INTERFACE_HPP

--- a/include/impl/Kokkos_Tuning_Interface.hpp
+++ b/include/impl/Kokkos_Tuning_Interface.hpp
@@ -40,17 +40,45 @@
  //
  // ************************************************************************
  //@HEADER
-*/
+ */
 
-#ifndef KOKKOSP_DEVICE_INFO_HPP
-#define KOKKOSP_DEVICE_INFO_HPP
+#ifndef KOKKOS_TUNING_INTERFACE_HPP
+#define KOKKOS_TUNING_INTERFACE_HPP
 
-#include <cstdint>
-#include <impl/Kokkos_Profiling_C_Interface.h>
+#include <impl/Kokkos_Tuning_C_Interface.h>
+
 namespace Kokkos {
-namespace Profiling {
-using KokkosPDeviceInfo = Kokkos_Profiling_KokkosPDeviceInfo;
-}  // namespace Profiling
-}  // namespace Kokkos
+namespace Tools {
 
-#endif
+using ValueSet            = Kokkos_Tuning_ValueSet;
+using ValueRange          = Kokkos_Tuning_ValueRange;
+using StatisticalCategory = Kokkos_Tuning_VariableInfo_StatisticalCategory;
+using ValueType           = Kokkos_Tuning_VariableInfo_ValueType;
+using CandidateValueType  = Kokkos_Tuning_VariableInfo_CandidateValueType;
+using SetOrRange          = Kokkos_Tuning_VariableInfo_SetOrRange;
+using VariableInfo        = Kokkos_Tuning_VariableInfo;
+using OptimizationGoal    = Kokkos_Tuning_OptimzationGoal;
+// TODO DZP: VariableInfo subclasses to automate some of this
+
+using VariableValue = Kokkos_Tuning_VariableValue;
+
+VariableValue make_variable_value(size_t id, bool val);
+VariableValue make_variable_value(size_t id, int64_t val);
+VariableValue make_variable_value(size_t id, double val);
+VariableValue make_variable_value(size_t id, const char* val);
+
+using tuningVariableDeclarationFunction =
+    Kokkos_Tuning_tuningVariableDeclarationFunction;
+using contextVariableDeclarationFunction =
+    Kokkos_Tuning_contextVariableDeclarationFunction;
+using tuningVariableValueFunction  = Kokkos_Tuning_tuningVariableValueFunction;
+using contextVariableValueFunction = Kokkos_Tuning_contextVariableValueFunction;
+using contextEndFunction           = Kokkos_Tuning_contextEndFunction;
+using optimizationGoalDeclarationFunction =
+    Kokkos_Tuning_optimizationGoalDeclarationFunction;
+
+}  // end namespace Tools
+
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_TUNING_INTERFACE_HPP

--- a/src/tools/exhaustive-tuner/Makefile
+++ b/src/tools/exhaustive-tuner/Makefile
@@ -1,0 +1,11 @@
+CXX=g++
+CXXFLAGS=-O2 -std=c++11 -g
+SHARED_CXXFLAGS=-shared -fPIC -I../../../include
+
+all: exhaustive_tuner.so
+
+exhaustive_tuner.so: exhaustive_tuner.cpp
+	$(CXX) $(SHARED_CXXFLAGS) $(CXXFLAGS) -o $@ exhaustive_tuner.cpp
+
+clean:
+	rm *.so

--- a/src/tools/exhaustive-tuner/Makefile
+++ b/src/tools/exhaustive-tuner/Makefile
@@ -1,4 +1,4 @@
-CXX=g++
+CXX=clang++
 CXXFLAGS=-O2 -std=c++11 -g
 SHARED_CXXFLAGS=-shared -fPIC -I../../../include
 

--- a/src/tools/exhaustive-tuner/exhaustive_tuner.cpp
+++ b/src/tools/exhaustive-tuner/exhaustive_tuner.cpp
@@ -1,0 +1,422 @@
+
+#include <cassert>
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
+
+#include <map>
+#include <queue>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <impl/Kokkos_Profiling_Interface.hpp>
+
+template <typename... Args>
+using MapType = std::map<Args...>;
+template <typename... Args>
+using SetType = std::set<Args...>;
+
+static MapType<size_t, Kokkos::Tuning::ValueType> var_info;
+
+namespace std {
+template <>
+struct less<Kokkos::Tuning::VariableValue> {
+        bool operator()(const Kokkos::Tuning::VariableValue& l,
+                        const Kokkos::Tuning::VariableValue& r) {
+                assert(var_info[l.id] == var_info[r.id]);
+                switch (var_info[l.id]) {
+                        case kokkos_value_boolean:
+                                return l.value.bool_value < r.value.bool_value;
+                        case kokkos_value_integer:
+                                return l.value.int_value < r.value.int_value;
+                        case kokkos_value_floating_point:
+                                return l.value.double_value <
+                                       r.value.double_value;
+                        case kokkos_value_text:
+                                return strncmp(l.value.string_value,
+                                               r.value.string_value, 1024);
+                }
+        }
+};
+}  // namespace std
+
+std::vector<std::string> regions;
+static uint64_t uniqID;
+
+extern "C" void kokkosp_init_library(const int loadSeq,
+                                     const uint64_t interfaceVer,
+                                     const uint32_t devInfoCount,
+                                     void* deviceInfo) {
+        printf(
+            "KokkosP: Example Tuner Library Initialized (sequence is %d, "
+            "version: %lu)\n",
+            loadSeq, interfaceVer);
+        uniqID = 0;
+}
+
+extern "C" void kokkosp_finalize_library() {
+        printf("KokkosP: Kokkos library finalization called.\n");
+}
+
+extern "C" void kokkosp_begin_parallel_for(const char* name,
+                                           const uint32_t devID,
+                                           uint64_t* kID) {}
+
+extern "C" void kokkosp_end_parallel_for(const uint64_t kID) {}
+
+extern "C" void kokkosp_begin_parallel_scan(const char* name,
+                                            const uint32_t devID,
+                                            uint64_t* kID) {}
+
+extern "C" void kokkosp_end_parallel_scan(const uint64_t kID) {}
+
+extern "C" void kokkosp_begin_parallel_reduce(const char* name,
+                                              const uint32_t devID,
+                                              uint64_t* kID) {}
+
+extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {}
+
+extern "C" void kokkosp_push_profile_region(char* regionName) {}
+
+extern "C" void kokkosp_pop_profile_region() {}
+
+extern "C" void kokkosp_allocate_data(Kokkos::Profiling::SpaceHandle handle,
+                                      const char* name, void* ptr,
+                                      uint64_t size) {}
+
+extern "C" void kokkosp_deallocate_data(Kokkos::Profiling::SpaceHandle handle,
+                                        const char* name, void* ptr,
+                                        uint64_t size) {}
+
+extern "C" void kokkosp_begin_deep_copy(
+    Kokkos::Profiling::SpaceHandle dst_handle, const char* dst_name,
+    const void* dst_ptr, Kokkos::Profiling::SpaceHandle src_handle,
+    const char* src_name, const void* src_ptr, uint64_t size) {}
+
+std::string getName(Kokkos_Tuning_VariableValue in) {
+        size_t id = in.id;
+        Kokkos::Tuning::ValueType type = var_info[id];
+        if (type == kokkos_value_boolean) {
+                return "Boolean";
+        } else if (type == kokkos_value_integer) {
+                return std::to_string(in.value.int_value);
+        } else if (type == kokkos_value_floating_point) {
+                return std::to_string(in.value.double_value);
+        } else if (type == kokkos_value_text) {
+                return in.value.string_value;
+        }
+        return "";  // TODO DZP: some kind of "unreachable." Also booleans.
+}
+
+#define FEATURE_ID_BITWIDTH (5)
+#define MAX_FEATURE_ID (2 << FEATURE_ID_BITWIDTH)
+
+/** Notes
+ *
+ * I am tuning these N parameters based on these X features
+ *
+ * First, hash all N's ID's
+ *
+ * Now I'm looking at feature values (will the features always be the same?
+ * Assume no)
+ *
+ * For each set of feature values, I have a set of performance results for the
+ * values of N
+ *
+ * Store those performance results in a priority_queue sorted by lowest number
+ * of encounters
+ *
+ * If the lowest is equal to the threshold, I'm done, use the fastest, otherwise
+ * use the lowest number of encounters
+ *
+ */
+
+struct FeatureSet {
+        size_t count;
+        const size_t* ids;
+        bool operator<(const FeatureSet& other) const {
+                if (count < other.count) {
+                        return true;
+                } else if (count > other.count) {
+                        return false;
+                } else {
+                        for (int x = 0; x < count; ++x) {
+                                if (ids[x] < other.ids[x]) {
+                                        return true;
+                                }
+                                if (ids[x] > other.ids[x]) {
+                                        return false;
+                                }
+                        }
+                }
+                return false;
+        }
+};
+
+using TuningParameterSet = FeatureSet;
+
+struct TuningParameterValues {
+        size_t count;
+        Kokkos::Tuning::VariableValue* values;
+        int times_encountered;
+        double time_value;
+        bool operator<(const TuningParameterValues& r) const {
+                return times_encountered < r.times_encountered;
+        }
+};
+
+bool Kokkos_Value_Less(const size_t l_id,
+                       const Kokkos::Tuning::VariableValue& l,
+                       const size_t r_id,
+                       const Kokkos::Tuning::VariableValue& r) {
+        assert(var_info[l_id] == var_info[r_id]);
+        switch (var_info[l_id]) {
+                case kokkos_value_boolean:  // TODO: should we allow boolean
+                                            // less?
+                        return l.value.bool_value < r.value.bool_value;
+                case kokkos_value_integer:
+                        return l.value.int_value < r.value.int_value;
+                case kokkos_value_floating_point:
+                        return l.value.double_value < r.value.double_value;
+                case kokkos_value_text:
+                        return strncmp(l.value.string_value,
+                                       r.value.string_value, 1024);
+        }
+}
+
+struct FeatureValues {
+        const size_t count;
+        const size_t* ids;
+        Kokkos::Tuning::VariableValue* values;
+        bool done;
+        TuningParameterValues ideal;
+        bool operator<(const FeatureValues& other) const {
+                if (count < other.count) {
+                        return true;
+                } else if (count > other.count) {
+                        return false;
+                } else {
+                        for (int x = 0; x < count; ++x) {
+                                if (Kokkos_Value_Less(ids[x], values[x],
+                                                      other.ids[x],
+                                                      other.values[x])) {
+                                        return true;
+                                } else if (Kokkos_Value_Less(
+                                               other.ids[x], other.values[x],
+                                               ids[x], values[x])) {
+                                        return false;
+                                }
+                        }
+                }
+                return false;
+        }
+};
+
+MapType<
+    TuningParameterSet,
+    MapType<FeatureSet,
+            MapType<FeatureValues, std::priority_queue<TuningParameterValues>>>>
+    performance_data;
+
+MapType<size_t, SetType<Kokkos::Tuning::VariableValue>> candidate_values;
+MapType<size_t, bool> candidate_is_set;  // TODO DZP: rewrite all these to be
+                                         // one size_t -> VariableInfo map
+
+Kokkos::Tuning::SetOrRange copy_candidate_values(
+    const Kokkos::Tuning::SetOrRange& in, bool isSet) {
+        Kokkos::Tuning::SetOrRange ret;
+        if (isSet) {
+                ret.set.size = in.set.size;
+                ret.set.values =
+                    new Kokkos::Tuning::VariableValue[ret.set.size];
+                std::copy(in.set.values, in.set.values + ret.set.size,
+                          ret.set.values);
+        } else {
+                ret.range = in.range;
+        }
+        return ret;
+}
+
+extern "C" void kokkosp_declare_tuning_variable(
+    const char* name, const size_t id, Kokkos::Tuning::VariableInfo info) {
+        printf("New variable named %s with id %zu\n", name, id);
+        var_info[id] = info.type;
+        candidate_is_set[id] = info.valueQuantity == kokkos_value_set;
+        // candidate_values[id] = copy_candidate_values(candidate_value,
+        // (info.valueQuantity == kokkos_value_set));
+}
+extern "C" void kokkosp_declare_context_variable(
+    const char* name, const size_t id, Kokkos::Tuning::VariableInfo info,
+    Kokkos::Tuning::SetOrRange candidate_value) {
+        printf("New variable named %s with id %zu\n", name, id);
+        var_info[id] = info.type;
+}
+
+template <typename... Args>
+using VectorType = std::vector<Args...>;
+
+using WorkingSet = VectorType<VectorType<Kokkos::Tuning::VariableValue>>;
+
+WorkingSet make_tuning_set_impl(WorkingSet& in, WorkingSet& add,
+                                int debug = 0) {
+        for (int x = debug * 2; x > 0; --x) {
+                std::cout << " ";
+        }
+        if (add.empty()) {
+                std::cout << "[mtsi] add_nothing {in.size=" << in.size()
+                          << "}\n";
+                return in;
+        }
+        if (in.empty()) {
+                std::vector<std::vector<Kokkos::Tuning::VariableValue>>
+                    start_set = {*add.erase(add.begin())};
+                std::cout << "[mtsi] in_nothing {start_set.size="<<start_set.size()<<"}\n";
+                // int foo = *start_set;
+                const auto& x = make_tuning_set_impl(start_set, add, debug + 1);
+                for (int x = debug * 2; x > 0; --x) {
+                        std::cout << " ";
+                }
+                std::cout << "[mtsi] in_nothing {return_size=" << x.size()
+                          << "}\n";
+
+                return x;
+        }
+        std::cout << "[mtsi] merging\n";
+        WorkingSet working;
+        std::vector<Kokkos::Tuning::VariableValue>& features =
+            *add.erase(add.begin());
+        for (auto& vec : in) {
+                for (auto& feature : features) {
+                        std::vector<Kokkos::Tuning::VariableValue> build_me{
+                            feature};
+                        std::copy(vec.begin(), vec.end(), build_me.begin());
+                        working.push_back(std::move(build_me));
+                }
+        }
+        return make_tuning_set_impl(working, add, debug + 1);
+}
+
+constexpr int num_samples = 5;
+
+// TODO DZP: this function is much truncated, is it still necessary?
+std::vector<Kokkos::Tuning::VariableValue> make_feature_vector(
+    const SetType<Kokkos::Tuning::VariableValue>& in) {
+        std::vector<Kokkos::Tuning::VariableValue> ret;
+        std::copy(in.begin(), in.end(), std::back_inserter(ret));
+        return ret;
+}
+
+TuningParameterValues values_from_vector(
+    std::vector<Kokkos::Tuning::VariableValue> in);
+
+TuningParameterValues makeTuningParameters(
+    const std::vector<Kokkos::Tuning::VariableValue>& in) {
+        TuningParameterValues ret;
+        ret.count = in.size();
+        ret.time_value = 0.0;
+        ret.times_encountered = 0;
+        ret.values = new Kokkos::Tuning::VariableValue[ret.count];
+
+        std::copy(in.begin(), in.end(), ret.values);
+        return ret;
+}
+
+std::priority_queue<TuningParameterValues> make_tuning_set(const size_t count,
+                                                           const size_t* ids) {
+        std::priority_queue<TuningParameterValues> ret;
+        WorkingSet in;
+        for (auto x = 0; x < count; ++x) {
+                auto candidate_values_for_feature = candidate_values[ids[x]];
+                int debug =0;
+                for(auto item: candidate_values_for_feature){
+                    std::cout << debug << "," <<getName(item)<<"\n";
+                }
+                std::cout <<"[mts] candidate_values for {"<<ids[x]<<"}, number of values {"<<candidate_values_for_feature.size()<<"}\n";
+                in.push_back(make_feature_vector(candidate_values_for_feature));
+        }
+        WorkingSet temp;  // TODO DZP: refactor
+        std::cout << "[mts] def not about to segault\n";
+        for (auto candidate : make_tuning_set_impl(temp, in)) {
+                ret.push(makeTuningParameters(candidate));
+        }
+        std::cout << "[mts] see, didn't segfault\n";
+
+        return ret;
+}
+
+extern "C" void kokkosp_request_tuning_variable_values(
+    const size_t contextId, const size_t numContextVariables,
+    const size_t* contextVariableIds,
+    const Kokkos::Tuning::VariableValue* contextVariableValues,
+    const size_t numTuningVariables, const size_t* tuningVariableIds,
+    Kokkos::Tuning::VariableValue* tuningVariableValues,
+    Kokkos::Tuning::SetOrRange* request_candidate_values) {
+        TuningParameterSet request_parameters = {numTuningVariables,
+                                                 tuningVariableIds};
+        FeatureSet features = {numContextVariables, contextVariableIds};
+        FeatureValues values = {numTuningVariables, tuningVariableIds,
+                                tuningVariableValues};
+        for (int x = 0; x < numTuningVariables; ++x) {
+                printf("Have value for context variable %zu, value is %s\n",
+                       contextVariableIds[x],
+                       getName(contextVariableValues[x]).c_str());
+        }
+        for (int x = 0; x < numTuningVariables; ++x) {
+                printf("Getting value for tuning variable %zu, value is %s\n",
+                       tuningVariableIds[x],
+                       getName(tuningVariableValues[x]).c_str());
+        }
+        for (int x = 0; x < numTuningVariables; ++x) {
+                const size_t variableId = tuningVariableIds[x];
+                if (candidate_is_set[variableId]) {
+                        bool newResults = false;
+                        for (auto iter = request_candidate_values[x].set.values;
+                             iter < request_candidate_values[x].set.values +
+                                        request_candidate_values[x].set.size;
+                             ++iter) {
+                                newResults |= candidate_values[variableId]
+                                                  .insert(*iter)
+                                                  .second;
+                                std::cout <<"[rtvv] insert on {"<<variableId<<"}\n";
+                        }  // TODO DZP: if newResults, add in the new values to
+                           // the training set
+                        if(newResults){
+                          // TODO handle actual extension, not just single values
+                          
+                        }
+                } else {
+                        // TODO DZP: handle ranges
+                }
+        }
+        auto& relevant_tuning = performance_data[request_parameters][features];
+        if (relevant_tuning.find(values) == relevant_tuning.end()) {
+                relevant_tuning[values] =
+                    make_tuning_set(numTuningVariables, tuningVariableIds);
+                size_t iter = 0;
+                while (!relevant_tuning[values].empty()) {
+                        ++iter;
+                        auto feature_values = relevant_tuning[values].top();
+                        relevant_tuning[values].pop();
+                        std::cout << iter << " number of features = "
+                                  << feature_values.count << " ";
+                        for (int inner_iter = 0;
+                             inner_iter < feature_values.count; ++inner_iter) {
+                                std::cout
+                                    << getName(
+                                           feature_values.values[inner_iter])
+                                    << ", ";
+                        }
+                        std::cout << "\n";
+                }
+        }
+        auto& tuning_set = relevant_tuning[values];
+        
+        for(int x =0;x<numTuningVariables;++x){
+          size_t id = tuningVariableIds[x]; 
+          
+        }
+}
+
+extern "C" void kokkosp_end_context(const size_t contextId) {}
+

--- a/src/tools/exhaustive-tuner/exhaustive_tuner.cpp
+++ b/src/tools/exhaustive-tuner/exhaustive_tuner.cpp
@@ -3,13 +3,15 @@
 #include <cinttypes>
 #include <cstdio>
 #include <cstring>
-
+#include <utility>
+#include <functional>
 #include <map>
 #include <queue>
 #include <set>
 #include <string>
 #include <vector>
-
+#include <chrono>
+#include <tuple>
 #include <impl/Kokkos_Profiling_Interface.hpp>
 
 template <typename... Args>
@@ -22,22 +24,18 @@ static MapType<size_t, Kokkos::Tuning::ValueType> var_info;
 namespace std {
 template <>
 struct less<Kokkos::Tuning::VariableValue> {
-        bool operator()(const Kokkos::Tuning::VariableValue& l,
-                        const Kokkos::Tuning::VariableValue& r) {
-                assert(var_info[l.id] == var_info[r.id]);
-                switch (var_info[l.id]) {
-                        case kokkos_value_boolean:
-                                return l.value.bool_value < r.value.bool_value;
-                        case kokkos_value_integer:
-                                return l.value.int_value < r.value.int_value;
-                        case kokkos_value_floating_point:
-                                return l.value.double_value <
-                                       r.value.double_value;
-                        case kokkos_value_text:
-                                return strncmp(l.value.string_value,
-                                               r.value.string_value, 1024);
-                }
-        }
+  bool operator()(const Kokkos::Tuning::VariableValue& l,
+                  const Kokkos::Tuning::VariableValue& r) {
+    assert(var_info[l.id] == var_info[r.id]);
+    switch (var_info[l.id]) {
+      case kokkos_value_boolean: return l.value.bool_value < r.value.bool_value;
+      case kokkos_value_integer: return l.value.int_value < r.value.int_value;
+      case kokkos_value_floating_point:
+        return l.value.double_value < r.value.double_value;
+      case kokkos_value_text:
+        return strncmp(l.value.string_value, r.value.string_value, 1024);
+    }
+  }
 };
 }  // namespace std
 
@@ -48,15 +46,15 @@ extern "C" void kokkosp_init_library(const int loadSeq,
                                      const uint64_t interfaceVer,
                                      const uint32_t devInfoCount,
                                      void* deviceInfo) {
-        printf(
-            "KokkosP: Example Tuner Library Initialized (sequence is %d, "
-            "version: %lu)\n",
-            loadSeq, interfaceVer);
-        uniqID = 0;
+  printf(
+      "KokkosP: Example Tuner Library Initialized (sequence is %d, "
+      "version: %lu)\n",
+      loadSeq, interfaceVer);
+  uniqID = 0;
 }
 
 extern "C" void kokkosp_finalize_library() {
-        printf("KokkosP: Kokkos library finalization called.\n");
+  printf("KokkosP: Kokkos library finalization called.\n");
 }
 
 extern "C" void kokkosp_begin_parallel_for(const char* name,
@@ -95,18 +93,18 @@ extern "C" void kokkosp_begin_deep_copy(
     const char* src_name, const void* src_ptr, uint64_t size) {}
 
 std::string getName(Kokkos_Tuning_VariableValue in) {
-        size_t id = in.id;
-        Kokkos::Tuning::ValueType type = var_info[id];
-        if (type == kokkos_value_boolean) {
-                return "Boolean";
-        } else if (type == kokkos_value_integer) {
-                return std::to_string(in.value.int_value);
-        } else if (type == kokkos_value_floating_point) {
-                return std::to_string(in.value.double_value);
-        } else if (type == kokkos_value_text) {
-                return in.value.string_value;
-        }
-        return "";  // TODO DZP: some kind of "unreachable." Also booleans.
+  size_t id                      = in.id;
+  Kokkos::Tuning::ValueType type = var_info[id];
+  if (type == kokkos_value_boolean) {
+    return (in.value.bool_value) ? "true" : "false";
+  } else if (type == kokkos_value_integer) {
+    return std::to_string(in.value.int_value);
+  } else if (type == kokkos_value_floating_point) {
+    return std::to_string(in.value.double_value);
+  } else if (type == kokkos_value_text) {
+    return in.value.string_value;
+  }
+  return "";  // TODO DZP: some kind of "unreachable." Also booleans.
 }
 
 #define FEATURE_ID_BITWIDTH (5)
@@ -128,95 +126,91 @@ std::string getName(Kokkos_Tuning_VariableValue in) {
  * of encounters
  *
  * If the lowest is equal to the threshold, I'm done, use the fastest, otherwise
- * use the lowest number of encounters
+ * use the tuning parameters I have encountered least
  *
  */
 
 struct FeatureSet {
-        size_t count;
-        const size_t* ids;
-        bool operator<(const FeatureSet& other) const {
-                if (count < other.count) {
-                        return true;
-                } else if (count > other.count) {
-                        return false;
-                } else {
-                        for (int x = 0; x < count; ++x) {
-                                if (ids[x] < other.ids[x]) {
-                                        return true;
-                                }
-                                if (ids[x] > other.ids[x]) {
-                                        return false;
-                                }
-                        }
-                }
-                return false;
+  size_t count;
+  const size_t* ids;
+  bool operator<(const FeatureSet& other) const {
+    if (count < other.count) {
+      return true;
+    } else if (count >= other.count) {
+      return false;
+    } else {
+      for (int x = 0; x < count; ++x) {
+        if (ids[x] < other.ids[x]) {
+          return true;
         }
+        if (ids[x] >= other.ids[x]) {
+          return false;
+        }
+      }
+    }
+    return false;
+  }
 };
 
 using TuningParameterSet = FeatureSet;
 
 struct TuningParameterValues {
-        size_t count;
-        Kokkos::Tuning::VariableValue* values;
-        int times_encountered;
-        double time_value;
-        bool operator<(const TuningParameterValues& r) const {
-                return times_encountered < r.times_encountered;
-        }
+  size_t count;
+  Kokkos::Tuning::VariableValue* values;
+  int times_encountered;
+  size_t time_value;
+  bool operator<(const TuningParameterValues& r) const {
+    return times_encountered > r.times_encountered;
+  }
 };
 
 bool Kokkos_Value_Less(const size_t l_id,
                        const Kokkos::Tuning::VariableValue& l,
                        const size_t r_id,
                        const Kokkos::Tuning::VariableValue& r) {
-        assert(var_info[l_id] == var_info[r_id]);
-        switch (var_info[l_id]) {
-                case kokkos_value_boolean:  // TODO: should we allow boolean
-                                            // less?
-                        return l.value.bool_value < r.value.bool_value;
-                case kokkos_value_integer:
-                        return l.value.int_value < r.value.int_value;
-                case kokkos_value_floating_point:
-                        return l.value.double_value < r.value.double_value;
-                case kokkos_value_text:
-                        return strncmp(l.value.string_value,
-                                       r.value.string_value, 1024);
-        }
+  assert(var_info[l_id] == var_info[r_id]);
+  switch (var_info[l_id]) {
+    case kokkos_value_boolean: return l.value.bool_value < r.value.bool_value;
+    case kokkos_value_integer: return l.value.int_value < r.value.int_value;
+    case kokkos_value_floating_point:
+      return l.value.double_value < r.value.double_value;
+    case kokkos_value_text:
+      return strncmp(l.value.string_value, r.value.string_value, 1024);
+  }
 }
 
 struct FeatureValues {
-        const size_t count;
-        const size_t* ids;
-        Kokkos::Tuning::VariableValue* values;
-        bool done;
-        TuningParameterValues ideal;
-        bool operator<(const FeatureValues& other) const {
-                if (count < other.count) {
-                        return true;
-                } else if (count > other.count) {
-                        return false;
-                } else {
-                        for (int x = 0; x < count; ++x) {
-                                if (Kokkos_Value_Less(ids[x], values[x],
-                                                      other.ids[x],
-                                                      other.values[x])) {
-                                        return true;
-                                } else if (Kokkos_Value_Less(
-                                               other.ids[x], other.values[x],
-                                               ids[x], values[x])) {
-                                        return false;
-                                }
-                        }
-                }
-                return false;
+  const size_t count;
+  const size_t* ids;
+  Kokkos::Tuning::VariableValue* values;
+  bool operator<(const FeatureValues& other) const {
+    if (count < other.count) {
+      return true;
+    } else if (count > other.count) {
+      return false;
+    } else {
+      for (int x = 0; x < count; ++x) {
+        if (Kokkos_Value_Less(ids[x], values[x], other.ids[x],
+                              other.values[x])) {
+          return true;
+        } else if (Kokkos_Value_Less(other.ids[x], other.values[x], ids[x],
+                                     values[x])) {
+          return false;
         }
+      }
+    }
+    return false;
+  }
 };
 
-MapType<
-    TuningParameterSet,
-    MapType<FeatureSet,
-            MapType<FeatureValues, std::priority_queue<TuningParameterValues>>>>
+struct TuningResults {
+  std::priority_queue<TuningParameterValues> candidates;
+  bool done;
+  TuningParameterValues ideal;
+};
+
+MapType<TuningParameterSet,
+        MapType<FeatureSet, MapType<FeatureValues, TuningResults>>>
     performance_data;
 
 MapType<size_t, SetType<Kokkos::Tuning::VariableValue>> candidate_values;
@@ -225,32 +219,31 @@ MapType<size_t, bool> candidate_is_set;  // TODO DZP: rewrite all these to be
 
 Kokkos::Tuning::SetOrRange copy_candidate_values(
     const Kokkos::Tuning::SetOrRange& in, bool isSet) {
-        Kokkos::Tuning::SetOrRange ret;
-        if (isSet) {
-                ret.set.size = in.set.size;
-                ret.set.values =
-                    new Kokkos::Tuning::VariableValue[ret.set.size];
-                std::copy(in.set.values, in.set.values + ret.set.size,
-                          ret.set.values);
-        } else {
-                ret.range = in.range;
-        }
-        return ret;
+  Kokkos::Tuning::SetOrRange ret;
+  if (isSet) {
+    ret.set.size   = in.set.size;
+    ret.set.values = new Kokkos::Tuning::VariableValue[ret.set.size];
+    std::copy(in.set.values, in.set.values + ret.set.size, ret.set.values);
+  } else {
+    ret.range = in.range;
+  }
+  return ret;
 }
 
 extern "C" void kokkosp_declare_tuning_variable(
     const char* name, const size_t id, Kokkos::Tuning::VariableInfo info) {
-        printf("New variable named %s with id %zu\n", name, id);
-        var_info[id] = info.type;
-        candidate_is_set[id] = info.valueQuantity == kokkos_value_set;
-        // candidate_values[id] = copy_candidate_values(candidate_value,
-        // (info.valueQuantity == kokkos_value_set));
+  printf("New variable named %s with id %zu\n", name, id);
+  var_info[id]         = info.type;
+  candidate_is_set[id] = info.valueQuantity == kokkos_value_set;
+  // candidate_values[id] = copy_candidate_values(candidate_value,
+  // (info.valueQuantity == kokkos_value_set));
 }
 extern "C" void kokkosp_declare_context_variable(
     const char* name, const size_t id, Kokkos::Tuning::VariableInfo info,
     Kokkos::Tuning::SetOrRange candidate_value) {
-        printf("New variable named %s with id %zu\n", name, id);
-        var_info[id] = info.type;
+  printf("New variable named %s with id %zu\n", name, id);
+  var_info[id]         = info.type;
+  candidate_is_set[id] = info.valueQuantity == kokkos_value_set;
 }
 
 template <typename... Args>
@@ -260,41 +253,38 @@ using WorkingSet = VectorType<VectorType<Kokkos::Tuning::VariableValue>>;
 
 WorkingSet make_tuning_set_impl(WorkingSet& in, WorkingSet& add,
                                 int debug = 0) {
-        for (int x = debug * 2; x > 0; --x) {
-                std::cout << " ";
-        }
-        if (add.empty()) {
-                std::cout << "[mtsi] add_nothing {in.size=" << in.size()
-                          << "}\n";
-                return in;
-        }
-        if (in.empty()) {
-                std::vector<std::vector<Kokkos::Tuning::VariableValue>>
-                    start_set = {*add.erase(add.begin())};
-                std::cout << "[mtsi] in_nothing {start_set.size="<<start_set.size()<<"}\n";
-                // int foo = *start_set;
-                const auto& x = make_tuning_set_impl(start_set, add, debug + 1);
-                for (int x = debug * 2; x > 0; --x) {
-                        std::cout << " ";
-                }
-                std::cout << "[mtsi] in_nothing {return_size=" << x.size()
-                          << "}\n";
+  if (add.empty()) {
+    //std::cout << "[mtsi] add_nothing {in.size=" << in.size() << "}\n";
+    return in;
+  }
+  if (in.empty()) {
+    std::vector<std::vector<Kokkos::Tuning::VariableValue>> start_set;
+    std::copy(add.begin(), add.end(), std::back_inserter(start_set));
+    add.erase(add.begin());
+    //std::cout << "[mtsi] in_nothing {start_set.size=" << start_set.size()
+    //          << "}\n";
+    // int foo = *start_set;
+    WorkingSet working;
+    for (auto item : start_set[0]) {
+      working.push_back(std::vector<Kokkos::Tuning::VariableValue>{item});
+    }
+    const auto& x = make_tuning_set_impl(working, add, debug + 1);
+    //std::cout << "[mtsi] in_nothing {return_size=" << x.size() << "}\n";
 
-                return x;
-        }
-        std::cout << "[mtsi] merging\n";
-        WorkingSet working;
-        std::vector<Kokkos::Tuning::VariableValue>& features =
-            *add.erase(add.begin());
-        for (auto& vec : in) {
-                for (auto& feature : features) {
-                        std::vector<Kokkos::Tuning::VariableValue> build_me{
-                            feature};
-                        std::copy(vec.begin(), vec.end(), build_me.begin());
-                        working.push_back(std::move(build_me));
-                }
-        }
-        return make_tuning_set_impl(working, add, debug + 1);
+    return x;
+  }
+  //std::cout << "[mtsi] merging\n";
+  WorkingSet working;
+  std::vector<Kokkos::Tuning::VariableValue>& features =
+      *add.erase(add.begin());
+  for (auto& vec : in) {
+    for (auto& feature : features) {
+      std::vector<Kokkos::Tuning::VariableValue> build_me{feature};
+      std::copy(vec.begin(), vec.end(), build_me.begin());
+      working.push_back(std::move(build_me));
+    }
+  }
+  return make_tuning_set_impl(working, add, debug + 1);
 }
 
 constexpr int num_samples = 5;
@@ -302,9 +292,9 @@ constexpr int num_samples = 5;
 // TODO DZP: this function is much truncated, is it still necessary?
 std::vector<Kokkos::Tuning::VariableValue> make_feature_vector(
     const SetType<Kokkos::Tuning::VariableValue>& in) {
-        std::vector<Kokkos::Tuning::VariableValue> ret;
-        std::copy(in.begin(), in.end(), std::back_inserter(ret));
-        return ret;
+  std::vector<Kokkos::Tuning::VariableValue> ret;
+  std::copy(in.begin(), in.end(), std::back_inserter(ret));
+  return ret;
 }
 
 TuningParameterValues values_from_vector(
@@ -312,39 +302,43 @@ TuningParameterValues values_from_vector(
 
 TuningParameterValues makeTuningParameters(
     const std::vector<Kokkos::Tuning::VariableValue>& in) {
-        TuningParameterValues ret;
-        ret.count = in.size();
-        ret.time_value = 0.0;
-        ret.times_encountered = 0;
-        ret.values = new Kokkos::Tuning::VariableValue[ret.count];
+  TuningParameterValues ret;
+  ret.count             = in.size();
+  ret.time_value        = 0;
+  ret.times_encountered = 0;
+  ret.values            = new Kokkos::Tuning::VariableValue[ret.count];
 
-        std::copy(in.begin(), in.end(), ret.values);
-        return ret;
+  std::copy(in.begin(), in.end(), ret.values);
+  return ret;
 }
 
 std::priority_queue<TuningParameterValues> make_tuning_set(const size_t count,
                                                            const size_t* ids) {
-        std::priority_queue<TuningParameterValues> ret;
-        WorkingSet in;
-        for (auto x = 0; x < count; ++x) {
-                auto candidate_values_for_feature = candidate_values[ids[x]];
-                int debug =0;
-                for(auto item: candidate_values_for_feature){
-                    std::cout << debug << "," <<getName(item)<<"\n";
-                }
-                std::cout <<"[mts] candidate_values for {"<<ids[x]<<"}, number of values {"<<candidate_values_for_feature.size()<<"}\n";
-                in.push_back(make_feature_vector(candidate_values_for_feature));
-        }
-        WorkingSet temp;  // TODO DZP: refactor
-        std::cout << "[mts] def not about to segault\n";
-        for (auto candidate : make_tuning_set_impl(temp, in)) {
-                ret.push(makeTuningParameters(candidate));
-        }
-        std::cout << "[mts] see, didn't segfault\n";
+  std::priority_queue<TuningParameterValues> ret;
+  WorkingSet in;
+  for (auto x = 0; x < count; ++x) {
+    auto candidate_values_for_feature = candidate_values[ids[x]];
+    int debug                         = 0;
+    auto feature_vector = make_feature_vector(candidate_values_for_feature);
+    //std::cout << "[mts] candidate_values for {" << ids[x]
+    //          << "}, number of values {" << candidate_values_for_feature.size()
+    //          << "}, features in each vector {}\n";
+    in.push_back(feature_vector);
+  }
+  WorkingSet temp;  // TODO DZP: refactor
+  //std::cout << "[mts] def not about to segault\n";
+  for (auto candidate : make_tuning_set_impl(temp, in)) {
+   // std::cout << "[mts] inserting candidate of size " << candidate.size()
+   //           << "\n";
 
-        return ret;
+    ret.push(makeTuningParameters(candidate));
+  }
+  //std::cout << "[mts] see, didn't segfault\n";
+
+  return ret;
 }
-
+MapType<size_t, std::vector<std::pair<std::reference_wrapper<TuningResults>,TuningParameterValues>>> live_values;
+MapType<size_t, decltype(std::chrono::system_clock::now())> running_timers;
 extern "C" void kokkosp_request_tuning_variable_values(
     const size_t contextId, const size_t numContextVariables,
     const size_t* contextVariableIds,
@@ -352,71 +346,97 @@ extern "C" void kokkosp_request_tuning_variable_values(
     const size_t numTuningVariables, const size_t* tuningVariableIds,
     Kokkos::Tuning::VariableValue* tuningVariableValues,
     Kokkos::Tuning::SetOrRange* request_candidate_values) {
-        TuningParameterSet request_parameters = {numTuningVariables,
-                                                 tuningVariableIds};
-        FeatureSet features = {numContextVariables, contextVariableIds};
-        FeatureValues values = {numTuningVariables, tuningVariableIds,
-                                tuningVariableValues};
-        for (int x = 0; x < numTuningVariables; ++x) {
-                printf("Have value for context variable %zu, value is %s\n",
-                       contextVariableIds[x],
-                       getName(contextVariableValues[x]).c_str());
+  TuningParameterSet request_parameters = {numTuningVariables,
+                                           tuningVariableIds};
+  FeatureSet features  = {numContextVariables, contextVariableIds};
+  FeatureValues values = {numTuningVariables, tuningVariableIds,
+                          tuningVariableValues};
+  for (int x = 0; x < numTuningVariables; ++x) {
+    //printf("Have value for context variable %zu, value is %s\n",
+    //       contextVariableIds[x], getName(contextVariableValues[x]).c_str());
+  }
+  for (int x = 0; x < numTuningVariables; ++x) {
+    //printf("Getting value for tuning variable %zu, value is %s\n",
+    //       tuningVariableIds[x], getName(tuningVariableValues[x]).c_str());
+  }
+  for (int x = 0; x < numTuningVariables; ++x) {
+    const size_t variableId = tuningVariableIds[x];
+    if (candidate_is_set[variableId]) {
+      bool newResults = false;
+      for (auto iter = request_candidate_values[x].set.values;
+           iter < request_candidate_values[x].set.values +
+                      request_candidate_values[x].set.size;
+           ++iter) {
+        //std::cout << "Inserting into map with id " << iter->id << std::endl;
+        auto insert_result = candidate_values[variableId].insert(
+            Kokkos::Tuning::VariableValue{iter->id, iter->value});
+        newResults |= insert_result.second;
+        //std::cout << "[rtvv] insert on {" << variableId << "}\n";
+      }  // TODO DZP: if newResults, add in the new values to
+         // the training set
+      if (newResults) {
+        // TODO handle actual extension, not just single
+        // values being right
+      }
+    } else {
+      // TODO DZP: handle ranges
+    }
+  }
+  auto& relevant_tuning = performance_data[request_parameters][features];
+  if (relevant_tuning.find(values) == relevant_tuning.end()) {
+    relevant_tuning[values] = {
+        make_tuning_set(numTuningVariables, tuningVariableIds), false};
+  }
+  auto& tuning_set = relevant_tuning[values];
+  if (tuning_set.done) {
+    auto& ideal = tuning_set.ideal;
+    for (int k = 0; k < tuning_set.ideal.count; ++k) {
+      for (int x = 0; x < numTuningVariables; ++x) {
+        if (tuningVariableIds[x] == tuning_set.ideal.values[k].id) {
+          tuningVariableValues[x] = tuning_set.ideal.values[k];
         }
-        for (int x = 0; x < numTuningVariables; ++x) {
-                printf("Getting value for tuning variable %zu, value is %s\n",
-                       tuningVariableIds[x],
-                       getName(tuningVariableValues[x]).c_str());
+      }
+    }
+  } else {
+    auto& candidate = tuning_set.candidates.top();
+    //std::cout << "Testing new values with " << candidate.count
+    //          << " chosen features\n";
+    for (int k = 0; k < candidate.count; ++k) {
+      //std::cout << "Searching for match on id " << candidate.values[k].id
+      //          << "\n";
+      for (int x = 0; x < numTuningVariables; ++x) {
+        if (tuningVariableIds[x] == candidate.values[k].id) {
+          //std::cout << "For varible with id " << tuningVariableIds[x]
+          //          << ", trying value " << getName(candidate.values[k])
+          //          << "\n";
+          tuningVariableValues[x] = candidate.values[k];
+          if (running_timers.find(contextId) == running_timers.end()) {
+            running_timers[contextId] = std::chrono::system_clock::now();
+            live_values[contextId].push_back(std::make_pair(std::ref(tuning_set), candidate));
+          }
         }
-        for (int x = 0; x < numTuningVariables; ++x) {
-                const size_t variableId = tuningVariableIds[x];
-                if (candidate_is_set[variableId]) {
-                        bool newResults = false;
-                        for (auto iter = request_candidate_values[x].set.values;
-                             iter < request_candidate_values[x].set.values +
-                                        request_candidate_values[x].set.size;
-                             ++iter) {
-                                newResults |= candidate_values[variableId]
-                                                  .insert(*iter)
-                                                  .second;
-                                std::cout <<"[rtvv] insert on {"<<variableId<<"}\n";
-                        }  // TODO DZP: if newResults, add in the new values to
-                           // the training set
-                        if(newResults){
-                          // TODO handle actual extension, not just single values
-                          
-                        }
-                } else {
-                        // TODO DZP: handle ranges
-                }
-        }
-        auto& relevant_tuning = performance_data[request_parameters][features];
-        if (relevant_tuning.find(values) == relevant_tuning.end()) {
-                relevant_tuning[values] =
-                    make_tuning_set(numTuningVariables, tuningVariableIds);
-                size_t iter = 0;
-                while (!relevant_tuning[values].empty()) {
-                        ++iter;
-                        auto feature_values = relevant_tuning[values].top();
-                        relevant_tuning[values].pop();
-                        std::cout << iter << " number of features = "
-                                  << feature_values.count << " ";
-                        for (int inner_iter = 0;
-                             inner_iter < feature_values.count; ++inner_iter) {
-                                std::cout
-                                    << getName(
-                                           feature_values.values[inner_iter])
-                                    << ", ";
-                        }
-                        std::cout << "\n";
-                }
-        }
-        auto& tuning_set = relevant_tuning[values];
-        
-        for(int x =0;x<numTuningVariables;++x){
-          size_t id = tuningVariableIds[x]; 
-          
-        }
+      }
+    }
+    tuning_set.candidates.pop();
+  }
 }
 
-extern "C" void kokkosp_end_context(const size_t contextId) {}
+extern "C" void kokkosp_end_context(const size_t contextId) {
+   if(running_timers.find(contextId)!=running_timers.end()) {
+     auto now = std::chrono::system_clock::now();
+     size_t elapsed =
+      std::chrono::duration_cast<std::chrono::seconds>(now - now).count();
+     for(auto tuning_values : live_values[contextId]){
+       auto& tuningResults = tuning_values.first;  
+       auto values = tuning_values.second;
+       values.time_value += elapsed;// TODO DZP: some overflow handling
+       values.times_encountered += 1;
+       //std::cout << "I've seen this value("<<getName(values.values[0])<<")"<<values.times_encountered<<" times \n";
+       tuningResults.get().candidates.push(values);
+       //std::cout << "Size is "<<tuningResults.get().candidates.size() << "\n";
+     }
+     live_values[contextId].clear();
+   }
+   running_timers.erase(contextId);
+}
 

--- a/src/tools/exhaustive-tuner/multipolicy.cpp
+++ b/src/tools/exhaustive-tuner/multipolicy.cpp
@@ -1,0 +1,142 @@
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Macros.hpp>
+#include <cmath>
+#include <array>
+#include <chrono>
+#include <thread>
+#include <iostream>
+constexpr const int num_iterations = 1000;
+constexpr const float penalty      = 0.1f;
+void sleep_difference(int actual, int guess) {
+  std::this_thread::sleep_for(
+      std::chrono::milliseconds(int(penalty * std::abs(guess - actual))));
+}
+
+size_t getBackendId(){
+        static size_t id;
+        static bool initialized;
+        if(!initialized){
+            initialized = true;    
+    id = Kokkos::Tuning::getNewVariableId();
+    Kokkos::Tuning::VariableInfo info;
+    info.type = kokkos_value_integer;
+    info.category = kokkos_value_categorical;
+    info.valueQuantity = kokkos_value_set;
+    Kokkos::Tuning::declareTuningVariable("kokkos.backend_choice",id,info); 
+        }
+        return id;
+}
+
+namespace impl {
+  template<typename... Devices>
+  struct executor; 
+  template<>
+  struct executor<> {
+
+    template<typename Functor>
+    static void execute(size_t index, const char* name, size_t lower, size_t upper, const Functor&& func){
+            return; // TODO DIE HERE
+    }
+  };
+  template<typename Device, typename... Devices>
+  struct executor<Device, Devices...> {
+    template<typename Functor>
+    static void execute(size_t index, const char* name, size_t lower, size_t upper, Functor&& func){
+      if(index==0){
+              Kokkos::parallel_for(name, Kokkos::RangePolicy<Device>(lower, upper), func);
+              return;
+      } 
+      executor<Devices...>::execute(index-1,name,lower,upper,std::forward<Functor>(func));
+    } 
+  };
+}
+
+
+template <typename... Devices>
+class PolyExecutor  {
+ public:
+  static PolyExecutor& instance() {
+    static PolyExecutor* executor;
+    if (!executor) {
+      executor = new PolyExecutor();
+    }
+    return *executor;
+  }
+  Kokkos::Tuning::VariableValue backend_variable_values[sizeof...(Devices)];
+  template<class Functor>
+  void execute(const char* name, size_t lower, size_t upper, Functor&& in){
+    size_t tuningContextId = Kokkos::Tuning::getNewContextId();
+    Kokkos::Tuning::SetOrRange candidates;
+    candidates.set.id = backend_variable_values[0].id;
+    candidates.set.size = sizeof...(Devices);
+    candidates.set.values = backend_variable_values;
+    Kokkos::Tuning::VariableValue picked_value = backend_variable_values[0];
+    Kokkos::Tuning::requestTuningVariableValues(tuningContextId, 1, &picked_value, &candidates);
+    impl::executor<Devices...>::execute(picked_value.value.int_value, name, lower, upper,  std::forward<Functor&&>(in)); 
+    Kokkos::Tuning::endContext(tuningContextId);
+  }
+ private:
+  PolyExecutor() {
+     //const char** value = { Devices::name()... };
+     size_t* ids = new size_t[sizeof...(Devices)];
+     for(int x =0 ;x<sizeof...(Devices);++x){
+       backend_variable_values[x] = Kokkos::Tuning::make_variable_value(getBackendId(), x);
+     }
+  }
+};
+
+        int main(int argc, char* argv[]) {
+  using Executor = PolyExecutor<Kokkos::Serial, Kokkos::OpenMP>;      
+  Kokkos::initialize(argc, argv);
+  size_t context_variable_id = Kokkos::Tuning::getNewVariableId();
+
+  // **now we *can* (aren't required to) declare candidate values
+  // *** a lower bound
+  Kokkos::Tuning::VariableValue range_lower =
+      Kokkos::Tuning::make_variable_value(context_variable_id, 0);
+  // *** an upper bound
+  Kokkos::Tuning::VariableValue range_upper =
+      Kokkos::Tuning::make_variable_value(context_variable_id, num_iterations);
+  // *** and a step size
+  Kokkos::Tuning::VariableValue range_step =
+      Kokkos::Tuning::make_variable_value(context_variable_id, 1);
+
+  Kokkos::Tuning::VariableInfo context_info;
+  // ** now we want to let the tool know about the semantics of that variable
+  // *** it's an integer
+  context_info.type          = kokkos_value_integer;
+  // *** it's 'interval', roughly meaning that subtracting two values makes sense
+  context_info.category      = kokkos_value_interval;
+  // *** and the candidate values are in a range, not a set 
+  context_info.valueQuantity = kokkos_value_range;
+  Kokkos::Tuning::SetOrRange value_range;
+
+  // ** this is just the earlier "range" construction
+  // ** the last two values are bools representing whether 
+  // ** the range is open (endpoints not included) or closed (endpoints included)
+  value_range.range = Kokkos::Tuning::ValueRange{
+      context_variable_id, &range_lower, &range_upper,
+      &range_step,         false,        false};
+  std::cout << "PRE DECLARE\n";
+  Kokkos::Tuning::declareContextVariable("target_value", context_variable_id,
+                                         context_info, value_range);
+  std::cout << "POST DECLARE\n";
+  {
+    Executor exec = Executor::instance();
+    for(int attempt =0;attempt<120;++attempt){
+    for (int work_intensity = 0; work_intensity < num_iterations;
+         work_intensity+=200) {
+      size_t contextId = Kokkos::Tuning::getNewContextId();
+      Kokkos::Tuning::VariableValue context_value = Kokkos::Tuning::make_variable_value(
+              context_variable_id, work_intensity);
+      Kokkos::Tuning::declareContextVariableValues(
+          contextId, 1, 
+          &context_value);
+    exec.execute("dogs",0,work_intensity, [&](const int id){});
+      //std::cout << "DOGS\n";
+      Kokkos::Tuning::endContext(contextId);
+    }
+    }
+  }
+  Kokkos::finalize();
+}

--- a/src/tools/exhaustive-tuner/tuning_example.cpp
+++ b/src/tools/exhaustive-tuner/tuning_example.cpp
@@ -110,11 +110,11 @@ int main(int argc, char* argv[]) {
       Kokkos::Tuning::VariableValue context_value = Kokkos::Tuning::make_variable_value(
               context_variable_id, work_intensity);
       Kokkos::Tuning::declareContextVariableValues(
-          contextId, 1, &context_variable_id,
+          contextId, 1, 
           &context_value);
             
       // *Now we ask the tool to give us the value it thinks will perform best
-      Kokkos::Tuning::requestTuningVariableValues(contextId, 1, &tuning_value_id, &tuned_choice, &candidate_values); 
+      Kokkos::Tuning::requestTuningVariableValues(contextId, 1, &tuned_choice, &candidate_values); 
 
       // *Call the function with those two values
       sleep_difference(work_intensity, tuned_choice.value.int_value);

--- a/src/tools/exhaustive-tuner/tuning_example.cpp
+++ b/src/tools/exhaustive-tuner/tuning_example.cpp
@@ -1,0 +1,80 @@
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Macros.hpp>
+#include <cmath>
+#include <array>
+#include <chrono>
+#include <thread>
+#include <iostream>
+
+constexpr const int num_iterations = 1000;
+constexpr const float penalty = 0.1f;
+void sleep_difference(int actual, int guess){
+        std::this_thread::sleep_for(std::chrono::milliseconds(int(penalty * std::abs(guess-actual))));
+}
+
+int main(int argc, char* argv[]) {
+  Kokkos::initialize(argc, argv);
+
+  size_t context_variable_id = Kokkos::Tuning::getNewVariableId();
+  Kokkos::Tuning::VariableValue range_lower =
+      Kokkos::Tuning::make_variable_value(context_variable_id, 0);
+  Kokkos::Tuning::VariableValue range_upper =
+      Kokkos::Tuning::make_variable_value(context_variable_id, num_iterations);
+  Kokkos::Tuning::VariableValue range_step =
+      Kokkos::Tuning::make_variable_value(context_variable_id, 1);
+  Kokkos::Tuning::VariableInfo context_info;
+  context_info.category      = kokkos_value_interval;
+  context_info.type          = kokkos_value_integer;
+  context_info.valueQuantity = kokkos_value_range;
+  Kokkos::Tuning::SetOrRange value_range;
+  value_range.range = Kokkos::Tuning::ValueRange{
+      context_variable_id, &range_lower, &range_upper,
+      &range_step,         false,        false};
+  Kokkos::Tuning::declareContextVariable("target_value", context_variable_id,
+                                         context_info, value_range);
+
+  size_t tuning_value_id = Kokkos::Tuning::getNewVariableId();
+  Kokkos::Tuning::VariableInfo tuning_variable_info;
+  tuning_variable_info.category      = kokkos_value_interval;
+  tuning_variable_info.type          = kokkos_value_integer;
+  tuning_variable_info.valueQuantity = kokkos_value_set;
+  Kokkos::Tuning::declareTuningVariable("tuned_choice", tuning_value_id,
+                                        tuning_variable_info);
+
+  Kokkos::Tuning::SetOrRange candidate_values;
+  std::vector<Kokkos::Tuning::VariableValue> candidate_value_array = {
+      Kokkos::Tuning::make_variable_value(tuning_value_id, 0),
+      Kokkos::Tuning::make_variable_value(tuning_value_id, 100),
+      Kokkos::Tuning::make_variable_value(tuning_value_id, 200),
+      Kokkos::Tuning::make_variable_value(tuning_value_id, 300),
+      Kokkos::Tuning::make_variable_value(tuning_value_id, 400),
+      Kokkos::Tuning::make_variable_value(tuning_value_id, 500),
+      Kokkos::Tuning::make_variable_value(tuning_value_id, 600),
+      Kokkos::Tuning::make_variable_value(tuning_value_id, 700),
+      Kokkos::Tuning::make_variable_value(tuning_value_id, 800),
+      Kokkos::Tuning::make_variable_value(tuning_value_id, 900),
+  };
+  candidate_values.set = Kokkos::Tuning::ValueSet{tuning_value_id, 10,
+                                                  candidate_value_array.data()};
+
+  {
+    Kokkos::Tuning::VariableValue tuned_choice;
+    tuned_choice.id = tuning_value_id;
+    tuned_choice.value.int_value = 0;
+    for(int attempt =0;attempt<120;++attempt){
+    for (int work_intensity = 0; work_intensity < num_iterations;
+         work_intensity+=200) {
+      std::cout << "Attempting a run with value "<<work_intensity<<std::endl;
+      size_t contextId = Kokkos::Tuning::getNewContextId();
+      Kokkos::Tuning::declareContextVariableValues(
+          contextId, 1, &context_variable_id,
+          new Kokkos::Tuning::VariableValue(Kokkos::Tuning::make_variable_value(
+              context_variable_id, work_intensity)));
+      Kokkos::Tuning::requestTuningVariableValues(contextId, 1, &tuning_value_id, &tuned_choice, &candidate_values); 
+      sleep_difference(work_intensity, tuned_choice.value.int_value);
+      Kokkos::Tuning::endContext(contextId);
+    }
+    }
+  }
+  Kokkos::finalize();
+}

--- a/src/tools/exhaustive-tuner/tuning_example.cpp
+++ b/src/tools/exhaustive-tuner/tuning_example.cpp
@@ -5,7 +5,7 @@
 #include <chrono>
 #include <thread>
 #include <iostream>
-
+#include <vector>
 constexpr const int num_iterations = 1000;
 constexpr const float penalty = 0.1f;
 void sleep_difference(int actual, int guess){
@@ -23,21 +23,21 @@ int main(int argc, char* argv[]) {
   // *Here we want to declare a context variable, something a tool might tune using
   //
   // **First we get an id for it
-  size_t context_variable_id = Kokkos::Tuning::getNewVariableId();
+  size_t context_variable_id = Kokkos::Tools::getNewVariableId();
 
   // **now we *can* (aren't required to) declare candidate values
   // *** a lower bound
-  Kokkos::Tuning::VariableValue range_lower =
-      Kokkos::Tuning::make_variable_value(context_variable_id, 0);
+  Kokkos::Tools::VariableValue range_lower =
+      Kokkos::Tools::make_variable_value(context_variable_id, int64_t(0));
   // *** an upper bound
-  Kokkos::Tuning::VariableValue range_upper =
-      Kokkos::Tuning::make_variable_value(context_variable_id, num_iterations);
+  Kokkos::Tools::VariableValue range_upper =
+      Kokkos::Tools::make_variable_value(context_variable_id, int64_t(num_iterations));
   // *** and a step size
-  Kokkos::Tuning::VariableValue range_step =
-      Kokkos::Tuning::make_variable_value(context_variable_id, 1);
+  Kokkos::Tools::VariableValue range_step =
+      Kokkos::Tools::make_variable_value(context_variable_id, int64_t(1));
 
 
-  Kokkos::Tuning::VariableInfo context_info;
+  Kokkos::Tools::VariableInfo context_info;
   // ** now we want to let the tool know about the semantics of that variable
   // *** it's an integer
   context_info.type          = kokkos_value_integer;
@@ -45,26 +45,26 @@ int main(int argc, char* argv[]) {
   context_info.category      = kokkos_value_interval;
   // *** and the candidate values are in a range, not a set 
   context_info.valueQuantity = kokkos_value_range;
-  Kokkos::Tuning::SetOrRange value_range;
+  Kokkos::Tools::SetOrRange value_range;
 
   // ** this is just the earlier "range" construction
   // ** the last two values are bools representing whether 
   // ** the range is open (endpoints not included) or closed (endpoints included)
-  value_range.range = Kokkos::Tuning::ValueRange{
+  value_range.range = Kokkos::Tools::ValueRange{
       context_variable_id, &range_lower, &range_upper,
       &range_step,         false,        false};
   // ** here we actually declare it to the tool
-  Kokkos::Tuning::declareContextVariable("target_value", context_variable_id,
+  Kokkos::Tools::declareContextVariable("target_value", context_variable_id,
                                          context_info, value_range);
 
 
   // * Now we're declaring the tuning variable
   // ** So we need an id for it
-  size_t tuning_value_id = Kokkos::Tuning::getNewVariableId();
+  size_t tuning_value_id = Kokkos::Tools::getNewVariableId();
 
   // ** its semantics exactly mirror the tuning variable, it's an
   // ** integer interval value
-  Kokkos::Tuning::VariableInfo tuning_variable_info;
+  Kokkos::Tools::VariableInfo tuning_variable_info;
   tuning_variable_info.category      = kokkos_value_interval;
   tuning_variable_info.type          = kokkos_value_integer;
 
@@ -72,29 +72,29 @@ int main(int argc, char* argv[]) {
   // ** 1) It shows the other side of this interface
   // ** 2) ... the prototype tool doesn't support guessing from ranges yet
   tuning_variable_info.valueQuantity = kokkos_value_set;
-  Kokkos::Tuning::declareTuningVariable("tuned_choice", tuning_value_id,
+  Kokkos::Tools::declareTuningVariable("tuned_choice", tuning_value_id,
                                         tuning_variable_info);
 
-  Kokkos::Tuning::SetOrRange candidate_values;
-  std::vector<Kokkos::Tuning::VariableValue> candidate_value_array = {
-      Kokkos::Tuning::make_variable_value(tuning_value_id, 0),
-      Kokkos::Tuning::make_variable_value(tuning_value_id, 100),
-      Kokkos::Tuning::make_variable_value(tuning_value_id, 200),
-      Kokkos::Tuning::make_variable_value(tuning_value_id, 300),
-      Kokkos::Tuning::make_variable_value(tuning_value_id, 400),
-      Kokkos::Tuning::make_variable_value(tuning_value_id, 500),
-      Kokkos::Tuning::make_variable_value(tuning_value_id, 600),
-      Kokkos::Tuning::make_variable_value(tuning_value_id, 700),
-      Kokkos::Tuning::make_variable_value(tuning_value_id, 800),
-      Kokkos::Tuning::make_variable_value(tuning_value_id, 900),
+  Kokkos::Tools::SetOrRange candidate_values;
+  std::vector<Kokkos::Tools::VariableValue> candidate_value_array {
+      Kokkos::Tools::make_variable_value(tuning_value_id, int64_t(0)),
+      Kokkos::Tools::make_variable_value(tuning_value_id, int64_t(100)),
+      Kokkos::Tools::make_variable_value(tuning_value_id, int64_t(200)),
+      Kokkos::Tools::make_variable_value(tuning_value_id, int64_t(300)),
+      Kokkos::Tools::make_variable_value(tuning_value_id, int64_t(400)),
+      Kokkos::Tools::make_variable_value(tuning_value_id, int64_t(500)),
+      Kokkos::Tools::make_variable_value(tuning_value_id, int64_t(600)),
+      Kokkos::Tools::make_variable_value(tuning_value_id, int64_t(700)),
+      Kokkos::Tools::make_variable_value(tuning_value_id, int64_t(800)),
+      Kokkos::Tools::make_variable_value(tuning_value_id, int64_t(900)),
   };
-  candidate_values.set = Kokkos::Tuning::ValueSet{tuning_value_id, 10,
+  candidate_values.set = Kokkos::Tools::ValueSet{tuning_value_id, 10,
                                                   candidate_value_array.data()};
 
   {
     // * declaring a VariableValue which can hold the results
     // *   of the tuning tool
-    Kokkos::Tuning::VariableValue tuned_choice;
+    Kokkos::Tools::VariableValue tuned_choice;
     tuned_choice.id = tuning_value_id;
     // ** Note that the default value must not crash the program
     tuned_choice.value.int_value = 0;
@@ -104,24 +104,24 @@ int main(int argc, char* argv[]) {
     for (int work_intensity = 0; work_intensity < num_iterations;
          work_intensity+=200) {
       std::cout << "Attempting a run with value "<<work_intensity<<std::endl;
-      size_t contextId = Kokkos::Tuning::getNewContextId();
+      size_t contextId = Kokkos::Tools::getNewContextId();
 
       // *Here we tell the tool the value of the context variable
-      Kokkos::Tuning::VariableValue context_value = Kokkos::Tuning::make_variable_value(
-              context_variable_id, work_intensity);
-      Kokkos::Tuning::declareContextVariableValues(
+      Kokkos::Tools::VariableValue context_value = Kokkos::Tools::make_variable_value(
+              context_variable_id, int64_t(work_intensity));
+      Kokkos::Tools::declareContextVariableValues(
           contextId, 1, 
           &context_value);
             
       // *Now we ask the tool to give us the value it thinks will perform best
-      Kokkos::Tuning::requestTuningVariableValues(contextId, 1, &tuned_choice, &candidate_values); 
+      Kokkos::Tools::requestTuningVariableValues(contextId, 1, &tuned_choice, &candidate_values); 
 
       // *Call the function with those two values
       sleep_difference(work_intensity, tuned_choice.value.int_value);
 
       // *This call tells the tool the context is over, so it can
       // *take measurements
-      Kokkos::Tuning::endContext(contextId);
+      Kokkos::Tools::endContext(contextId);
     }
     }
   }

--- a/src/tools/exhaustive-tuner/tuning_example.cpp
+++ b/src/tools/exhaustive-tuner/tuning_example.cpp
@@ -9,34 +9,68 @@
 constexpr const int num_iterations = 1000;
 constexpr const float penalty = 0.1f;
 void sleep_difference(int actual, int guess){
-        std::this_thread::sleep_for(std::chrono::milliseconds(int(penalty * std::abs(guess-actual))));
+  std::this_thread::sleep_for(std::chrono::milliseconds(int(penalty * std::abs(guess-actual))));
 }
 
-int main(int argc, char* argv[]) {
-  Kokkos::initialize(argc, argv);
+// This is a simple tuning example, in which we have a function that takes two values and
+// sleeps for their difference. The tool is given one value, and asked to guess the other
+//
+// The correct answer is to guess the same value the tool was given in the context
 
+int main(int argc, char* argv[]) {
+
+  Kokkos::initialize(argc, argv);
+  // *Here we want to declare a context variable, something a tool might tune using
+  //
+  // **First we get an id for it
   size_t context_variable_id = Kokkos::Tuning::getNewVariableId();
+
+  // **now we *can* (aren't required to) declare candidate values
+  // *** a lower bound
   Kokkos::Tuning::VariableValue range_lower =
       Kokkos::Tuning::make_variable_value(context_variable_id, 0);
+  // *** an upper bound
   Kokkos::Tuning::VariableValue range_upper =
       Kokkos::Tuning::make_variable_value(context_variable_id, num_iterations);
+  // *** and a step size
   Kokkos::Tuning::VariableValue range_step =
       Kokkos::Tuning::make_variable_value(context_variable_id, 1);
+
+
   Kokkos::Tuning::VariableInfo context_info;
-  context_info.category      = kokkos_value_interval;
+  // ** now we want to let the tool know about the semantics of that variable
+  // *** it's an integer
   context_info.type          = kokkos_value_integer;
+  // *** it's 'interval', roughly meaning that subtracting two values makes sense
+  context_info.category      = kokkos_value_interval;
+  // *** and the candidate values are in a range, not a set 
   context_info.valueQuantity = kokkos_value_range;
   Kokkos::Tuning::SetOrRange value_range;
+
+  // ** this is just the earlier "range" construction
+  // ** the last two values are bools representing whether 
+  // ** the range is open (endpoints not included) or closed (endpoints included)
   value_range.range = Kokkos::Tuning::ValueRange{
       context_variable_id, &range_lower, &range_upper,
       &range_step,         false,        false};
+  // ** here we actually declare it to the tool
   Kokkos::Tuning::declareContextVariable("target_value", context_variable_id,
                                          context_info, value_range);
 
+
+  // * Now we're declaring the tuning variable
+  // ** So we need an id for it
   size_t tuning_value_id = Kokkos::Tuning::getNewVariableId();
+
+  // ** its semantics exactly mirror the tuning variable, it's an
+  // ** integer interval value
   Kokkos::Tuning::VariableInfo tuning_variable_info;
   tuning_variable_info.category      = kokkos_value_interval;
   tuning_variable_info.type          = kokkos_value_integer;
+
+  // ** Here I'm setting the candidate values to be from a set for two reasons
+  // ** 1) It shows the other side of this interface
+  // ** 2) ... the prototype tool doesn't support guessing from ranges yet
   tuning_variable_info.valueQuantity = kokkos_value_set;
   Kokkos::Tuning::declareTuningVariable("tuned_choice", tuning_value_id,
                                         tuning_variable_info);
@@ -58,20 +92,35 @@ int main(int argc, char* argv[]) {
                                                   candidate_value_array.data()};
 
   {
+    // * declaring a VariableValue which can hold the results
+    // *   of the tuning tool
     Kokkos::Tuning::VariableValue tuned_choice;
     tuned_choice.id = tuning_value_id;
+    // ** Note that the default value must not crash the program
     tuned_choice.value.int_value = 0;
+
+    // * Looping multiple times so the tool can converge
     for(int attempt =0;attempt<120;++attempt){
     for (int work_intensity = 0; work_intensity < num_iterations;
          work_intensity+=200) {
       std::cout << "Attempting a run with value "<<work_intensity<<std::endl;
       size_t contextId = Kokkos::Tuning::getNewContextId();
+
+      // *Here we tell the tool the value of the context variable
+      Kokkos::Tuning::VariableValue context_value = Kokkos::Tuning::make_variable_value(
+              context_variable_id, work_intensity);
       Kokkos::Tuning::declareContextVariableValues(
           contextId, 1, &context_variable_id,
-          new Kokkos::Tuning::VariableValue(Kokkos::Tuning::make_variable_value(
-              context_variable_id, work_intensity)));
+          &context_value);
+            
+      // *Now we ask the tool to give us the value it thinks will perform best
       Kokkos::Tuning::requestTuningVariableValues(contextId, 1, &tuning_value_id, &tuned_choice, &candidate_values); 
+
+      // *Call the function with those two values
       sleep_difference(work_intensity, tuned_choice.value.int_value);
+
+      // *This call tells the tool the context is over, so it can
+      // *take measurements
       Kokkos::Tuning::endContext(contextId);
     }
     }


### PR DESCRIPTION
Included is `tuning_example.cpp`, which shows a simple example which uses this. In Kokkos, we currently (on the branch in the PR for kokkos/kokkos#2422 ) tune block size with this interface, and that functions as an example as well.

This is an exhaustive tuner: for every set of context variable values, it tries every set of tuning variable values. This is the most naive possible functional tuner, but it's useful because it allows you to do parameter sweeps and see what every value does, not just the best one.

Unless discussion really needs to be here, I prefer it happen over on kokkos/kokkos, so there's only one thread of execution