### PR TITLE
Disable printing to screen in memory-events

### DIFF
--- a/src/tools/memory-events/kp_memory_events.cpp
+++ b/src/tools/memory-events/kp_memory_events.cpp
@@ -145,7 +145,6 @@ extern "C" void kokkosp_allocate_data(const SpaceHandle space, const char* label
 
   int i=events.size();
   events.push_back(EventRecord(ptr,size,MEMOP_ALLOCATE,space_i,time,label));
-  events.back().print_record();
 }
 
 

--- a/src/tools/memory-events/kp_memory_events.hpp
+++ b/src/tools/memory-events/kp_memory_events.hpp
@@ -84,8 +84,5 @@ struct EventRecord {
     if(operation == MEMOP_POP_REGION)
       fprintf(ofile,"%lf } PopRegion %s\n",time,name);
   }
-  void print_record() const {
-    print_record(stdout);
-  }
 };
 


### PR DESCRIPTION
Same as #74 but targeting `develop`.