### PR TITLE
Fixed comments.

### DIFF
--- a/profiling/papi-connector/kp_papi_connector.cpp
+++ b/profiling/papi-connector/kp_papi_connector.cpp
@@ -66,7 +66,7 @@ extern "C" void kokkosp_init_library(const int loadSeq,
    /* The following advanced functions of PAPI's high-level API are not part
     * of the official release. But they might be introduced in later PAPI releases.
     * PAPI_hl_init is now called from the first PAPI_hl_region_begin call.
-    * /
+    */
    //PAPI_hl_init();
    /* set default values */
    //PAPI_hl_set_events("perf::TASK-CLOCK,PAPI_TOT_INS,PAPI_TOT_CYC,PAPI_FP_OPS");
@@ -78,7 +78,7 @@ extern "C" void kokkosp_finalize_library()
     * of the official release. But they might be introduced in later PAPI releases.
     * PAPI_hl_print_output is registered by the "atexit" function and will be called
     * at process termination, see http://man7.org/linux/man-pages/man3/atexit.3.html.
-    * /
+    */
    //PAPI_hl_print_output();
    //PAPI_hl_finalize();
 


### PR DESCRIPTION
A space at the end of two comments resulted in the entire source code being commented out.