### PR TITLE
Add cstring to kp_kernel_info.h for GCC 10

### DIFF
--- a/profiling/simple-kernel-timer/kp_kernel_info.h
+++ b/profiling/simple-kernel-timer/kp_kernel_info.h
@@ -45,6 +45,7 @@
 
 #include <stdio.h>
 #include <sys/time.h>
+#include <string>
 #include <cstring>
 
 #if defined(__GXX_ABI_VERSION)


### PR DESCRIPTION
Hi,

I was trying to use the simple-kernel-timer tool, following the tutorial lectures. When I compile with the provided makefile, which uses `g++` (10.2.0 on my laptop), I get the error message
```
g++ -shared -fPIC -O3 -std=c++11 -g -I/home/anders/kokkos-tools/profiling/simple-kernel-timer/ -o kp_kernel_timer.so /home/anders/kokkos-tools/profiling/simple-kernel-timer/kp_kernel_timer.cpp
g++ -O3 -std=c++11 -g -I/home/anders/kokkos-tools/profiling/simple-kernel-timer/ -o kp_reader /home/anders/kokkos-tools/profiling/simple-kernel-timer/kp_reader.cpp
In file included from /home/anders/kokkos-tools/profiling/simple-kernel-timer/kp_reader.cpp:50:
/home/anders/kokkos-tools/profiling/simple-kernel-timer/kp_kernel_info.h:87:36: error: expected ‘)’ before ‘kName’
   87 |   KernelPerformanceInfo(std::string kName, KernelExecutionType kernelType) :
      |                        ~           ^~~~~~
      |
```
Changing to `clang++` gives the more illuminating message
```
clang++ -O3 -std=c++11 -g -I/home/anders/kokkos-tools/profiling/simple-kernel-timer/ -o kp_reader /home/anders/kokkos-tools/profiling/simple-kernel-timer/kp_reader.cpp
In file included from /home/anders/kokkos-tools/profiling/simple-kernel-timer/kp_reader.cpp:50:
/home/anders/kokkos-tools/profiling/simple-kernel-timer/kp_kernel_info.h:87:30: error: no type named 'string' in namespace 'std'
                KernelPerformanceInfo(std::string kName, KernelExecutionType kernelType) :
```
The error is resolved by adding
```
#include <string>
```
to `kp_kernel_info.h`.


This was a bit of a surprising error, as I watched @crtrott compile without issue in the Kokkos lectures. I'm guessing it's related to this section in [Porting to GCC 10](https://gcc.gnu.org/gcc-10/porting_to.html):
> ### C++ language issues
> #### Header dependency changes
> Some C++ Standard Library headers have been changed to no longer include the `<stdexcept>` header. As such, C++ programs that used components defined in `<stdexcept>` or `<string>` without explicitly including the right headers will no longer compile.
> Previously components such as `std::runtime_error`, `std::string` and `std::allocator` were implicitly defined after including unrelated headers such as `<array>` and `<optional>`. Correct code should include the appropriate headers for the classes being used.