### PR TITLE
Sampling overlay prototype

### DIFF
--- a/common/passthrough/Makefile
+++ b/common/passthrough/Makefile
@@ -1,0 +1,13 @@
+CXX=g++
+CXXFLAGS=-O3 -std=c++11 -g -I../../include
+SHARED_CXXFLAGS=-shared -fPIC
+
+all: kp_passthrough.so
+
+MAKEFILE_PATH := $(subst Makefile,,$(abspath $(lastword $(MAKEFILE_LIST))))
+
+kp_passthrough.so: ${MAKEFILE_PATH}passthrough.cpp
+	$(CXX) $(SHARED_CXXFLAGS) $(CXXFLAGS) -o $@ ${MAKEFILE_PATH}passthrough.cpp
+
+clean:
+	rm *.so

--- a/common/passthrough/passthrough.cpp
+++ b/common/passthrough/passthrough.cpp
@@ -1,0 +1,148 @@
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cxxabi.h>
+#include <dlfcn.h>
+#include <impl/Kokkos_Profiling_Interface.hpp>
+#include <iostream>
+#include <regex>
+#include <string>
+#include <tool_chain.hpp>
+#include <unordered_set>
+#include <vector>
+static Kokkos::Tools::callback_chainer next;
+extern "C" void kokkosp_begin_parallel_scan(const char *name,
+                                            const uint32_t devID,
+                                            uint64_t *kID) {
+  next.kokkosp_begin_parallel_scan(name, devID, kID);
+}
+extern "C" void kokkosp_begin_parallel_for(const char *name,
+                                           const uint32_t devID,
+                                           uint64_t *kID) {
+  next.kokkosp_begin_parallel_for(name, devID, kID);
+}
+extern "C" void kokkosp_begin_parallel_reduce(const char *name,
+                                              const uint32_t devID,
+                                              uint64_t *kID) {
+
+  next.kokkosp_begin_parallel_reduce(name, devID, kID);
+}
+extern "C" void kokkosp_end_parallel_scan(uint64_t kID) {
+  next.kokkosp_end_parallel_scan(kID);
+}
+extern "C" void kokkosp_end_parallel_for(uint64_t kID) {
+  next.kokkosp_end_parallel_for(kID);
+}
+extern "C" void kokkosp_end_parallel_reduce(uint64_t kID) {
+  next.kokkosp_end_parallel_reduce(kID);
+}
+extern "C" void
+kokkosp_init_library(int loadseq, uint64_t version, uint32_t ndevinfos,
+                     Kokkos_Profiling_KokkosPDeviceInfo *devInfos) {
+  next.setup(loadseq);
+  next.kokkosp_init_library(loadseq, version, ndevinfos, devInfos);
+}
+extern "C" void kokkosp_finalize_library() { next.kokkosp_finalize_library(); }
+extern "C" void kokkosp_push_profile_region(const char *name) {
+  next.kokkosp_push_profile_region(name);
+}
+extern "C" void kokkosp_pop_profile_region() {
+  next.kokkosp_pop_profile_region();
+}
+extern "C" void kokkosp_allocate_data(Kokkos::Profiling::SpaceHandle handle,
+                                      const char *name, void *ptr,
+                                      uint64_t size) {
+  next.kokkosp_allocate_data(handle, name, ptr, size);
+}
+extern "C" void kokkosp_deallocate_data(Kokkos::Profiling::SpaceHandle handle,
+                                        const char *name, void *ptr,
+                                        uint64_t size) {
+  next.kokkosp_deallocate_data(handle, name, ptr, size);
+}
+extern "C" void kokkosp_begin_deep_copy(Kokkos::Tools::SpaceHandle dst_handle,
+                                        const char *dst_name,
+                                        const void *dst_ptr,
+                                        Kokkos::Tools::SpaceHandle src_handle,
+                                        const char *src_name,
+                                        const void *src_ptr, uint64_t size) {
+  next.kokkosp_begin_deep_copy(dst_handle, dst_name, dst_ptr, src_handle,
+                               src_name, src_ptr, size);
+}
+extern "C" void kokkosp_end_deep_copy() { next.kokkosp_end_deep_copy(); }
+extern "C" void kokkosp_begin_fence(const char *name, const uint32_t devID,
+                                    uint64_t *kID) {
+  next.kokkosp_begin_fence(name, devID, kID);
+}
+extern "C" void kokkosp_end_fence(uint64_t kID) { next.kokkosp_end_fence(kID); }
+extern "C" void kokkosp_dual_view_sync(const char *label, const void *const ptr,
+                                       bool to_device) {
+  next.kokkosp_dual_view_sync(label, ptr, to_device);
+}
+extern "C" void kokkosp_dual_view_modify(const char *label,
+                                         const void *const ptr,
+                                         bool to_device) {
+  next.kokkosp_dual_view_modify(label, ptr, to_device);
+}
+extern "C" void kokkosp_declare_metadata(const char *key, const char *value) {
+  next.kokkosp_declare_metadata(key, value);
+}
+extern "C" void kokkosp_create_profile_section(const char *name,
+                                               uint32_t *sec_id) {
+  next.kokkosp_create_profile_section(name, sec_id);
+}
+extern "C" void kokkosp_start_profile_section(uint32_t sec_id) {
+  next.kokkosp_start_profile_section(sec_id);
+}
+extern "C" void kokkosp_stop_profile_section(uint32_t sec_id) {
+  next.kokkosp_stop_profile_section(sec_id);
+}
+extern "C" void kokkosp_destroy_profile_section(uint32_t sec_id) {
+  next.kokkosp_destroy_profile_section(sec_id);
+}
+extern "C" void kokkosp_profile_event(const char *name) {
+  next.kokkosp_profile_event(name);
+}
+extern "C" void
+kokkosp_declare_output_type(const char *name, size_t id,
+                            Kokkos::Tools::Experimental::VariableInfo *info) {
+  next.kokkosp_declare_output_type(name, id, info);
+}
+extern "C" void
+kokkosp_declare_input_type(const char *name, size_t id,
+                           Kokkos::Tools::Experimental::VariableInfo *info) {
+  next.kokkosp_declare_input_type(name, id, info);
+}
+extern "C" void kokkosp_request_values(
+    size_t context_id, size_t num_context_values,
+    Kokkos::Tools::Experimental::VariableValue *context_values,
+    size_t num_output_values,
+    Kokkos::Tools::Experimental::VariableValue *output_values) {
+  next.kokkosp_request_values(context_id, num_context_values, context_values,
+                              num_output_values, output_values);
+}
+extern "C" void kokkosp_end_context(size_t context_id) {
+  next.kokkosp_end_context(context_id);
+}
+extern "C" void kokkosp_begin_context(size_t context_id) {
+  next.kokkosp_begin_context(context_id);
+}
+extern "C" void kokkosp_declare_optimization_goal(
+    size_t context_id, Kokkos::Tools::Experimental::OptimizationGoal goal) {
+  next.kokkosp_declare_optimization_goal(context_id, goal);
+}
+extern "C" void kokkosp_print_help(char *arg0) {
+  next.kokkosp_print_help(arg0);
+}
+extern "C" void kokkosp_parse_args(int argc, char **argv) {
+
+  next.kokkosp_parse_args(argc, argv);
+}
+extern "C" void
+kokkosp_transmit_actions(Kokkos::Tools::Experimental::ToolActions actions) {
+  next.kokkosp_transmit_actions(actions);
+}
+extern "C" void kokkosp_request_responses(
+    Kokkos::Tools::Experimental::ToolResponses *responses) {
+  next.kokkosp_request_responses(responses);
+}

--- a/common/sampler/Makefile
+++ b/common/sampler/Makefile
@@ -1,0 +1,13 @@
+CXX=g++
+CXXFLAGS=-O3 -std=c++11 -g -I../../include
+SHARED_CXXFLAGS=-shared -fPIC
+
+all: kp_sampler.so
+
+MAKEFILE_PATH := $(subst Makefile,,$(abspath $(lastword $(MAKEFILE_LIST))))
+
+kp_sampler.so: ${MAKEFILE_PATH}sampler.cpp
+	$(CXX) $(SHARED_CXXFLAGS) $(CXXFLAGS) -o $@ ${MAKEFILE_PATH}sampler.cpp
+
+clean:
+	rm *.so

--- a/common/sampler/sampler.cpp
+++ b/common/sampler/sampler.cpp
@@ -1,0 +1,186 @@
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cxxabi.h>
+#include <dlfcn.h>
+#include <impl/Kokkos_Profiling_Interface.hpp>
+#include <iostream>
+#include <regex>
+#include <string>
+#include <tool_chain.hpp>
+#include <unordered_set>
+#include <vector>
+static Kokkos::Tools::callback_chainer next;
+using action_type = Kokkos::Tools::Experimental::ToolActions;
+action_type actions;
+static uint64_t sample_rate = 101;
+
+extern "C" void kokkosp_begin_parallel_scan(const char *name,
+                                            const uint32_t devID,
+                                            uint64_t *kID) {
+  *kID = 0;
+  static uint64_t encounter;
+  ++encounter;
+  if ((encounter % sample_rate) == 0) {
+    actions.fence(0);
+    *kID = 1;
+    next.kokkosp_begin_parallel_scan(name, devID, kID);
+  }
+}
+extern "C" void kokkosp_begin_parallel_for(const char *name,
+                                           const uint32_t devID,
+                                           uint64_t *kID) {
+  *kID = 0;
+  static uint64_t encounter;
+  ++encounter;
+  if ((encounter % sample_rate) == 0) {
+    actions.fence(0);
+    *kID = 1;
+    next.kokkosp_begin_parallel_for(name, devID, kID);
+  }
+}
+extern "C" void kokkosp_begin_parallel_reduce(const char *name,
+                                              const uint32_t devID,
+                                              uint64_t *kID) {
+  *kID = 0;
+  static uint64_t encounter;
+  ++encounter;
+  if ((encounter % sample_rate) == 0) {
+    actions.fence(0);
+    *kID = 1;
+    next.kokkosp_begin_parallel_reduce(name, devID, kID);
+  }
+}
+extern "C" void kokkosp_end_parallel_scan(uint64_t kID) {
+  if (kID > 0) {
+    actions.fence(0);
+    next.kokkosp_end_parallel_scan(kID);
+  }
+}
+extern "C" void kokkosp_end_parallel_for(uint64_t kID) {
+  if (kID > 0) {
+    actions.fence(0);
+    next.kokkosp_end_parallel_for(kID);
+  }
+}
+extern "C" void kokkosp_end_parallel_reduce(uint64_t kID) {
+  if (kID > 0) {
+    actions.fence(0);
+    next.kokkosp_end_parallel_reduce(kID);
+  }
+}
+#include <iostream>
+extern "C" void
+kokkosp_init_library(int loadseq, uint64_t version, uint32_t ndevinfos,
+                     Kokkos_Profiling_KokkosPDeviceInfo *devInfos) {
+  next.setup(loadseq);
+  next.kokkosp_init_library(loadseq, version, ndevinfos, devInfos);
+}
+extern "C" void kokkosp_finalize_library() { next.kokkosp_finalize_library(); }
+extern "C" void kokkosp_push_profile_region(const char *name) {
+  actions.fence(0);
+  next.kokkosp_push_profile_region(name);
+}
+extern "C" void kokkosp_pop_profile_region() {
+  actions.fence(0);
+  next.kokkosp_pop_profile_region();
+}
+extern "C" void kokkosp_allocate_data(Kokkos::Profiling::SpaceHandle handle,
+                                      const char *name, void *ptr,
+                                      uint64_t size) {
+  next.kokkosp_allocate_data(handle, name, ptr, size);
+}
+extern "C" void kokkosp_deallocate_data(Kokkos::Profiling::SpaceHandle handle,
+                                        const char *name, void *ptr,
+                                        uint64_t size) {
+  next.kokkosp_deallocate_data(handle, name, ptr, size);
+}
+extern "C" void kokkosp_begin_deep_copy(Kokkos::Tools::SpaceHandle dst_handle,
+                                        const char *dst_name,
+                                        const void *dst_ptr,
+                                        Kokkos::Tools::SpaceHandle src_handle,
+                                        const char *src_name,
+                                        const void *src_ptr, uint64_t size) {
+  next.kokkosp_begin_deep_copy(dst_handle, dst_name, dst_ptr, src_handle,
+                               src_name, src_ptr, size);
+}
+extern "C" void kokkosp_end_deep_copy() { next.kokkosp_end_deep_copy(); }
+extern "C" void kokkosp_begin_fence(const char *name, const uint32_t devID,
+                                    uint64_t *kID) {
+  next.kokkosp_begin_fence(name, devID, kID);
+}
+extern "C" void kokkosp_end_fence(uint64_t kID) { next.kokkosp_end_fence(kID); }
+extern "C" void kokkosp_dual_view_sync(const char *label, const void *const ptr,
+                                       bool to_device) {
+  next.kokkosp_dual_view_sync(label, ptr, to_device);
+}
+extern "C" void kokkosp_dual_view_modify(const char *label,
+                                         const void *const ptr,
+                                         bool to_device) {
+  next.kokkosp_dual_view_modify(label, ptr, to_device);
+}
+extern "C" void kokkosp_declare_metadata(const char *key, const char *value) {
+  next.kokkosp_declare_metadata(key, value);
+}
+extern "C" void kokkosp_create_profile_section(const char *name,
+                                               uint32_t *sec_id) {
+  next.kokkosp_create_profile_section(name, sec_id);
+}
+extern "C" void kokkosp_start_profile_section(uint32_t sec_id) {
+  next.kokkosp_start_profile_section(sec_id);
+}
+extern "C" void kokkosp_stop_profile_section(uint32_t sec_id) {
+  next.kokkosp_stop_profile_section(sec_id);
+}
+extern "C" void kokkosp_destroy_profile_section(uint32_t sec_id) {
+  next.kokkosp_destroy_profile_section(sec_id);
+}
+extern "C" void kokkosp_profile_event(const char *name) {
+  next.kokkosp_profile_event(name);
+}
+extern "C" void
+kokkosp_declare_output_type(const char *name, size_t id,
+                            Kokkos::Tools::Experimental::VariableInfo *info) {
+  next.kokkosp_declare_output_type(name, id, info);
+}
+extern "C" void
+kokkosp_declare_input_type(const char *name, size_t id,
+                           Kokkos::Tools::Experimental::VariableInfo *info) {
+  next.kokkosp_declare_input_type(name, id, info);
+}
+extern "C" void kokkosp_request_values(
+    size_t context_id, size_t num_context_values,
+    Kokkos::Tools::Experimental::VariableValue *context_values,
+    size_t num_output_values,
+    Kokkos::Tools::Experimental::VariableValue *output_values) {
+  next.kokkosp_request_values(context_id, num_context_values, context_values,
+                              num_output_values, output_values);
+}
+extern "C" void kokkosp_end_context(size_t context_id) {
+  next.kokkosp_end_context(context_id);
+}
+extern "C" void kokkosp_begin_context(size_t context_id) {
+  next.kokkosp_begin_context(context_id);
+}
+extern "C" void kokkosp_declare_optimization_goal(
+    size_t context_id, Kokkos::Tools::Experimental::OptimizationGoal goal) {
+  next.kokkosp_declare_optimization_goal(context_id, goal);
+}
+extern "C" void kokkosp_print_help(char *arg0) {
+  next.kokkosp_print_help(arg0);
+}
+extern "C" void kokkosp_parse_args(int argc, char **argv) {
+
+  next.kokkosp_parse_args(argc, argv);
+}
+extern "C" void
+kokkosp_transmit_actions(Kokkos::Tools::Experimental::ToolActions nactions) {
+  actions = nactions;
+  next.kokkosp_transmit_actions(nactions);
+}
+extern "C" void kokkosp_request_responses(
+    Kokkos::Tools::Experimental::ToolResponses *responses) {
+  responses->requires_global_fencing = false;
+  next.kokkosp_request_responses(responses);
+}

--- a/include/impl/Kokkos_Profiling_C_Interface.h
+++ b/include/impl/Kokkos_Profiling_C_Interface.h
@@ -1,0 +1,297 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_PROFILING_C_INTERFACE_HPP
+#define KOKKOS_PROFILING_C_INTERFACE_HPP
+
+#ifdef __cplusplus
+#include <cstddef>
+#include <cstdint>
+#else
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#endif
+
+#define KOKKOSP_INTERFACE_VERSION 20210225
+
+// Profiling
+
+struct Kokkos_Profiling_KokkosPDeviceInfo {
+  size_t deviceID;
+};
+
+struct Kokkos_Profiling_SpaceHandle {
+  char name[64];
+};
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_initFunction)(
+    const int, const uint64_t, const uint32_t,
+    struct Kokkos_Profiling_KokkosPDeviceInfo*);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_finalizeFunction)();
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_parseArgsFunction)(int, char**);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_printHelpFunction)(char*);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_beginFunction)(const char*, const uint32_t,
+                                               uint64_t*);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_endFunction)(uint64_t);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_pushFunction)(const char*);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_popFunction)();
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_allocateDataFunction)(
+    const struct Kokkos_Profiling_SpaceHandle, const char*, const void*,
+    const uint64_t);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_deallocateDataFunction)(
+    const struct Kokkos_Profiling_SpaceHandle, const char*, const void*,
+    const uint64_t);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_createProfileSectionFunction)(const char*,
+                                                              uint32_t*);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_startProfileSectionFunction)(const uint32_t);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_stopProfileSectionFunction)(const uint32_t);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_destroyProfileSectionFunction)(const uint32_t);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_profileEventFunction)(const char*);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_beginDeepCopyFunction)(
+    struct Kokkos_Profiling_SpaceHandle, const char*, const void*,
+    struct Kokkos_Profiling_SpaceHandle, const char*, const void*, uint64_t);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_endDeepCopyFunction)();
+typedef void (*Kokkos_Profiling_beginFenceFunction)(const char*, const uint32_t,
+                                                    uint64_t*);
+typedef void (*Kokkos_Profiling_endFenceFunction)(uint64_t);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_dualViewSyncFunction)(const char*,
+                                                      const void* const, bool);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_dualViewModifyFunction)(const char*,
+                                                        const void* const,
+                                                        bool);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_declareMetadataFunction)(const char*,
+                                                         const char*);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Tools_toolInvokedFenceFunction)(const uint32_t);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Tools_function_pointer)();
+struct Kokkos_Tools_ToolActions {
+  int num_supported_actions;
+  Kokkos_Tools_toolInvokedFenceFunction fence;
+  // allow addition of more actions
+  Kokkos_Tools_function_pointer padding[31];
+};
+
+struct Kokkos_Tools_ToolResponses {
+  int num_supported_responses;
+  bool requires_global_fencing;
+  bool padding[255];
+};
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Tools_transmitActionsFunction)(
+    struct Kokkos_Tools_ToolActions);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Tools_requestResponsesFunction)(
+    struct Kokkos_Tools_ToolResponses*);
+
+// Tuning
+
+#define KOKKOS_TOOLS_TUNING_STRING_LENGTH 64
+typedef char Kokkos_Tools_Tuning_String[KOKKOS_TOOLS_TUNING_STRING_LENGTH];
+union Kokkos_Tools_VariableValue_ValueUnion {
+  int64_t int_value;
+  double double_value;
+  Kokkos_Tools_Tuning_String string_value;
+};
+
+union Kokkos_Tools_VariableValue_ValueUnionSet {
+  int64_t* int_value;
+  double* double_value;
+  Kokkos_Tools_Tuning_String* string_value;
+};
+
+struct Kokkos_Tools_ValueSet {
+  size_t size;
+  union Kokkos_Tools_VariableValue_ValueUnionSet values;
+};
+
+enum Kokkos_Tools_OptimizationType {
+  Kokkos_Tools_Minimize,
+  Kokkos_Tools_Maximize
+};
+
+struct Kokkos_Tools_OptimzationGoal {
+  size_t type_id;
+  enum Kokkos_Tools_OptimizationType goal;
+};
+
+struct Kokkos_Tools_ValueRange {
+  union Kokkos_Tools_VariableValue_ValueUnion lower;
+  union Kokkos_Tools_VariableValue_ValueUnion upper;
+  union Kokkos_Tools_VariableValue_ValueUnion step;
+  bool openLower;
+  bool openUpper;
+};
+
+enum Kokkos_Tools_VariableInfo_ValueType {
+  kokkos_value_double,
+  kokkos_value_int64,
+  kokkos_value_string,
+};
+
+enum Kokkos_Tools_VariableInfo_StatisticalCategory {
+  kokkos_value_categorical,  // unordered distinct objects
+  kokkos_value_ordinal,      // ordered distinct objects
+  kokkos_value_interval,  // ordered distinct objects for which distance matters
+  kokkos_value_ratio  // ordered distinct objects for which distance matters,
+                      // division matters, and the concept of zero exists
+};
+
+enum Kokkos_Tools_VariableInfo_CandidateValueType {
+  kokkos_value_set,       // I am one of [2,3,4,5]
+  kokkos_value_range,     // I am somewhere in [2,12)
+  kokkos_value_unbounded  // I am [text/int/float], but we don't know at
+                          // declaration time what values are appropriate. Only
+                          // valid for Context Variables
+};
+
+union Kokkos_Tools_VariableInfo_SetOrRange {
+  struct Kokkos_Tools_ValueSet set;
+  struct Kokkos_Tools_ValueRange range;
+};
+
+struct Kokkos_Tools_VariableInfo {
+  enum Kokkos_Tools_VariableInfo_ValueType type;
+  enum Kokkos_Tools_VariableInfo_StatisticalCategory category;
+  enum Kokkos_Tools_VariableInfo_CandidateValueType valueQuantity;
+  union Kokkos_Tools_VariableInfo_SetOrRange candidates;
+  void* toolProvidedInfo;
+};
+
+struct Kokkos_Tools_VariableValue {
+  size_t type_id;
+  union Kokkos_Tools_VariableValue_ValueUnion value;
+  struct Kokkos_Tools_VariableInfo* metadata;
+};
+
+typedef void (*Kokkos_Tools_outputTypeDeclarationFunction)(
+    const char*, const size_t, struct Kokkos_Tools_VariableInfo* info);
+typedef void (*Kokkos_Tools_inputTypeDeclarationFunction)(
+    const char*, const size_t, struct Kokkos_Tools_VariableInfo* info);
+
+typedef void (*Kokkos_Tools_requestValueFunction)(
+    const size_t, const size_t, const struct Kokkos_Tools_VariableValue*,
+    const size_t count, struct Kokkos_Tools_VariableValue*);
+typedef void (*Kokkos_Tools_contextBeginFunction)(const size_t);
+typedef void (*Kokkos_Tools_contextEndFunction)(
+    const size_t, struct Kokkos_Tools_VariableValue);
+typedef void (*Kokkos_Tools_optimizationGoalDeclarationFunction)(
+    const size_t, const struct Kokkos_Tools_OptimzationGoal goal);
+
+struct Kokkos_Profiling_EventSet {
+  Kokkos_Profiling_initFunction init;
+  Kokkos_Profiling_finalizeFunction finalize;
+  Kokkos_Profiling_parseArgsFunction parse_args;
+  Kokkos_Profiling_printHelpFunction print_help;
+  Kokkos_Profiling_beginFunction begin_parallel_for;
+  Kokkos_Profiling_endFunction end_parallel_for;
+  Kokkos_Profiling_beginFunction begin_parallel_reduce;
+  Kokkos_Profiling_endFunction end_parallel_reduce;
+  Kokkos_Profiling_beginFunction begin_parallel_scan;
+  Kokkos_Profiling_endFunction end_parallel_scan;
+  Kokkos_Profiling_pushFunction push_region;
+  Kokkos_Profiling_popFunction pop_region;
+  Kokkos_Profiling_allocateDataFunction allocate_data;
+  Kokkos_Profiling_deallocateDataFunction deallocate_data;
+  Kokkos_Profiling_createProfileSectionFunction create_profile_section;
+  Kokkos_Profiling_startProfileSectionFunction start_profile_section;
+  Kokkos_Profiling_stopProfileSectionFunction stop_profile_section;
+  Kokkos_Profiling_destroyProfileSectionFunction destroy_profile_section;
+  Kokkos_Profiling_profileEventFunction profile_event;
+  Kokkos_Profiling_beginDeepCopyFunction begin_deep_copy;
+  Kokkos_Profiling_endDeepCopyFunction end_deep_copy;
+  Kokkos_Profiling_beginFenceFunction begin_fence;
+  Kokkos_Profiling_endFenceFunction end_fence;
+  Kokkos_Profiling_dualViewSyncFunction sync_dual_view;
+  Kokkos_Profiling_dualViewModifyFunction modify_dual_view;
+  Kokkos_Profiling_declareMetadataFunction declare_metadata;
+  Kokkos_Tools_transmitActionsFunction transmit_actions;
+  Kokkos_Tools_requestResponsesFunction request_responses;
+  char profiling_padding[9 * sizeof(Kokkos_Tools_function_pointer)];
+  Kokkos_Tools_outputTypeDeclarationFunction declare_output_type;
+  Kokkos_Tools_inputTypeDeclarationFunction declare_input_type;
+  Kokkos_Tools_requestValueFunction request_output_values;
+  Kokkos_Tools_contextBeginFunction begin_tuning_context;
+  Kokkos_Tools_contextEndFunction end_tuning_context;
+  Kokkos_Tools_optimizationGoalDeclarationFunction declare_optimization_goal;
+  char padding[232 *
+               sizeof(
+                   Kokkos_Tools_function_pointer)];  // allows us to add another
+                                                     // 256 events to the Tools
+                                                     // interface without
+                                                     // changing struct layout
+};
+
+#endif  // KOKKOS_PROFILING_C_INTERFACE_HPP

--- a/include/impl/Kokkos_Profiling_DeviceInfo.hpp
+++ b/include/impl/Kokkos_Profiling_DeviceInfo.hpp
@@ -1,0 +1,56 @@
+/*
+ //@HEADER
+ // ************************************************************************
+ //
+ //                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+ //
+ // Under the terms of Contract DE-NA0003525 with NTESS,
+ // the U.S. Government retains certain rights in this software.
+ //
+ // Redistribution and use in source and binary forms, with or without
+ // modification, are permitted provided that the following conditions are
+ // met:
+ //
+ // 1. Redistributions of source code must retain the above copyright
+ // notice, this list of conditions and the following disclaimer.
+ //
+ // 2. Redistributions in binary form must reproduce the above copyright
+ // notice, this list of conditions and the following disclaimer in the
+ // documentation and/or other materials provided with the distribution.
+ //
+ // 3. Neither the name of the Corporation nor the names of the
+ // contributors may be used to endorse or promote products derived from
+ // this software without specific prior written permission.
+ //
+ // THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+ // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ // PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+ // CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ // EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ // PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ // PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ //
+ // Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+ //
+ // ************************************************************************
+ //@HEADER
+*/
+
+#ifndef KOKKOSP_DEVICE_INFO_HPP
+#define KOKKOSP_DEVICE_INFO_HPP
+
+#include <cstdint>
+#include <impl/Kokkos_Profiling_C_Interface.h>
+namespace Kokkos {
+namespace Profiling {
+using KokkosPDeviceInfo = Kokkos_Profiling_KokkosPDeviceInfo;
+}  // namespace Profiling
+}  // namespace Kokkos
+
+#endif

--- a/include/impl/Kokkos_Profiling_Interface.hpp
+++ b/include/impl/Kokkos_Profiling_Interface.hpp
@@ -1,0 +1,214 @@
+/*
+ //@HEADER
+ // ************************************************************************
+ //
+ //                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+ //
+ // Under the terms of Contract DE-NA0003525 with NTESS,
+ // the U.S. Government retains certain rights in this software.
+ //
+ // Redistribution and use in source and binary forms, with or without
+ // modification, are permitted provided that the following conditions are
+ // met:
+ //
+ // 1. Redistributions of source code must retain the above copyright
+ // notice, this list of conditions and the following disclaimer.
+ //
+ // 2. Redistributions in binary form must reproduce the above copyright
+ // notice, this list of conditions and the following disclaimer in the
+ // documentation and/or other materials provided with the distribution.
+ //
+ // 3. Neither the name of the Corporation nor the names of the
+ // contributors may be used to endorse or promote products derived from
+ // this software without specific prior written permission.
+ //
+ // THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+ // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ // PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+ // CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ // EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ // PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ // PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ //
+ // Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+ //
+ // ************************************************************************
+ //@HEADER
+ */
+
+#ifndef KOKKOSP_INTERFACE_HPP
+#define KOKKOSP_INTERFACE_HPP
+
+#include <cinttypes>
+#include <cstddef>
+
+#include <cstdlib>
+
+// NOTE: in this Kokkos::Profiling block, do not define anything that shouldn't
+// exist should Profiling be disabled
+
+namespace Kokkos {
+namespace Tools {
+namespace Experimental {
+enum struct DeviceType {
+  Serial,
+  OpenMP,
+  Cuda,
+  HIP,
+  OpenMPTarget,
+  HPX,
+  Threads,
+  SYCL,
+  Unknown
+};
+
+template <typename ExecutionSpace>
+struct DeviceTypeTraits;
+
+constexpr const size_t device_type_bits = 8;
+constexpr const size_t instance_bits    = 24;
+template <typename ExecutionSpace>
+inline uint32_t device_id(ExecutionSpace const& space) noexcept {
+  auto device_id = static_cast<uint32_t>(DeviceTypeTraits<ExecutionSpace>::id);
+  return (device_id << instance_bits) + space.impl_instance_id();
+}
+}  // namespace Experimental
+}  // namespace Tools
+}  // end namespace Kokkos
+
+#if defined(KOKKOS_ENABLE_LIBDL)
+// We check at configure time that libdl is available.
+#include <dlfcn.h>
+#endif
+
+#include <impl/Kokkos_Profiling_DeviceInfo.hpp>
+#include <impl/Kokkos_Profiling_C_Interface.h>
+
+namespace Kokkos {
+namespace Tools {
+
+using SpaceHandle = Kokkos_Profiling_SpaceHandle;
+
+}  // namespace Tools
+
+namespace Tools {
+
+namespace Experimental {
+using EventSet = Kokkos_Profiling_EventSet;
+static_assert(sizeof(EventSet) / sizeof(Kokkos_Tools_function_pointer) == 275,
+              "sizeof EventSet has changed, this is an error on the part of a "
+              "Kokkos developer");
+
+using toolInvokedFenceFunction = Kokkos_Tools_toolInvokedFenceFunction;
+using transmitActionsFunction  = Kokkos_Tools_transmitActionsFunction;
+using requestResponseFunction  = Kokkos_Tools_requestResponsesFunction;
+using ToolResponses            = Kokkos_Tools_ToolResponses;
+using ToolActions              = Kokkos_Tools_ToolActions;
+}  // namespace Experimental
+using initFunction           = Kokkos_Profiling_initFunction;
+using finalizeFunction       = Kokkos_Profiling_finalizeFunction;
+using parseArgsFunction      = Kokkos_Profiling_parseArgsFunction;
+using printHelpFunction      = Kokkos_Profiling_printHelpFunction;
+using beginFunction          = Kokkos_Profiling_beginFunction;
+using endFunction            = Kokkos_Profiling_endFunction;
+using pushFunction           = Kokkos_Profiling_pushFunction;
+using popFunction            = Kokkos_Profiling_popFunction;
+using allocateDataFunction   = Kokkos_Profiling_allocateDataFunction;
+using deallocateDataFunction = Kokkos_Profiling_deallocateDataFunction;
+using createProfileSectionFunction =
+    Kokkos_Profiling_createProfileSectionFunction;
+using startProfileSectionFunction =
+    Kokkos_Profiling_startProfileSectionFunction;
+using stopProfileSectionFunction = Kokkos_Profiling_stopProfileSectionFunction;
+using destroyProfileSectionFunction =
+    Kokkos_Profiling_destroyProfileSectionFunction;
+using profileEventFunction    = Kokkos_Profiling_profileEventFunction;
+using beginDeepCopyFunction   = Kokkos_Profiling_beginDeepCopyFunction;
+using endDeepCopyFunction     = Kokkos_Profiling_endDeepCopyFunction;
+using beginFenceFunction      = Kokkos_Profiling_beginFenceFunction;
+using endFenceFunction        = Kokkos_Profiling_endFenceFunction;
+using dualViewSyncFunction    = Kokkos_Profiling_dualViewSyncFunction;
+using dualViewModifyFunction  = Kokkos_Profiling_dualViewModifyFunction;
+using declareMetadataFunction = Kokkos_Profiling_declareMetadataFunction;
+
+}  // namespace Tools
+
+}  // namespace Kokkos
+
+// Profiling
+
+namespace Kokkos {
+
+namespace Profiling {
+
+/** The Profiling namespace is being renamed to Tools.
+ * This is reexposing the contents of what used to be the Profiling
+ * Interface with their original names, to avoid breaking old code
+ */
+
+namespace Experimental {
+
+using Kokkos::Tools::Experimental::device_id;
+using Kokkos::Tools::Experimental::DeviceType;
+using Kokkos::Tools::Experimental::DeviceTypeTraits;
+
+}  // namespace Experimental
+
+using Kokkos::Tools::allocateDataFunction;
+using Kokkos::Tools::beginDeepCopyFunction;
+using Kokkos::Tools::beginFunction;
+using Kokkos::Tools::createProfileSectionFunction;
+using Kokkos::Tools::deallocateDataFunction;
+using Kokkos::Tools::destroyProfileSectionFunction;
+using Kokkos::Tools::endDeepCopyFunction;
+using Kokkos::Tools::endFunction;
+using Kokkos::Tools::finalizeFunction;
+using Kokkos::Tools::initFunction;
+using Kokkos::Tools::parseArgsFunction;
+using Kokkos::Tools::popFunction;
+using Kokkos::Tools::printHelpFunction;
+using Kokkos::Tools::profileEventFunction;
+using Kokkos::Tools::pushFunction;
+using Kokkos::Tools::SpaceHandle;
+using Kokkos::Tools::startProfileSectionFunction;
+using Kokkos::Tools::stopProfileSectionFunction;
+
+}  // namespace Profiling
+}  // namespace Kokkos
+
+// Tuning
+
+namespace Kokkos {
+namespace Tools {
+namespace Experimental {
+using ValueSet            = Kokkos_Tools_ValueSet;
+using ValueRange          = Kokkos_Tools_ValueRange;
+using StatisticalCategory = Kokkos_Tools_VariableInfo_StatisticalCategory;
+using ValueType           = Kokkos_Tools_VariableInfo_ValueType;
+using CandidateValueType  = Kokkos_Tools_VariableInfo_CandidateValueType;
+using SetOrRange          = Kokkos_Tools_VariableInfo_SetOrRange;
+using VariableInfo        = Kokkos_Tools_VariableInfo;
+using OptimizationGoal    = Kokkos_Tools_OptimzationGoal;
+using TuningString        = Kokkos_Tools_Tuning_String;
+using VariableValue       = Kokkos_Tools_VariableValue;
+
+using outputTypeDeclarationFunction =
+    Kokkos_Tools_outputTypeDeclarationFunction;
+using inputTypeDeclarationFunction = Kokkos_Tools_inputTypeDeclarationFunction;
+using requestValueFunction         = Kokkos_Tools_requestValueFunction;
+using contextBeginFunction         = Kokkos_Tools_contextBeginFunction;
+using contextEndFunction           = Kokkos_Tools_contextEndFunction;
+using optimizationGoalDeclarationFunction =
+    Kokkos_Tools_optimizationGoalDeclarationFunction;
+}  // end namespace Experimental
+}  // end namespace Tools
+
+}  // end namespace Kokkos
+
+#endif

--- a/include/tool_chain.hpp
+++ b/include/tool_chain.hpp
@@ -1,0 +1,338 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+
+#include "impl/Kokkos_Profiling_Interface.hpp"
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cxxabi.h>
+#include <dlfcn.h>
+#include <iostream>
+#include <regex>
+#include <string>
+#include <unordered_set>
+#include <vector>
+namespace Kokkos {
+
+namespace Tools {
+template <typename Callback>
+void lookup_function(void *dlopen_handle, const std::string &basename,
+                     Callback &callback) {
+  void *p = dlsym(dlopen_handle, basename.c_str());
+  callback = *reinterpret_cast<Callback *>(&p);
+}
+
+struct callback_chainer {
+  Kokkos::Tools::Experimental::EventSet next_events;
+  using responses = Kokkos::Tools::Experimental::ToolResponses;
+  using actions = Kokkos::Tools::Experimental::ToolActions;
+  responses tool_requirements;
+  actions tool_actions;
+  int load_seq;
+  template <typename Callback, typename BooleanConstant, typename... Args>
+  void call_kokkos_callback(const Callback callback, BooleanConstant,
+                            Args... args) {
+    if (callback != nullptr) {
+      if ((BooleanConstant::value) &&
+          (tool_requirements.requires_global_fencing) && (load_seq == 0)) {
+        tool_actions.fence(0);
+      }
+      (*callback)(args...);
+    }
+  }
+  void setup(int loadSeq) {
+    void *handle;
+    char *profileLibrary = getenv("KOKKOS_PROFILE_LIBRARY");
+    char *envBuffer =
+        (char *)malloc(sizeof(char) * (strlen(profileLibrary) + 1));
+    sprintf(envBuffer, "%s", profileLibrary);
+
+    char *nextLibrary = strtok(envBuffer, ";");
+
+    for (int i = 0; i < loadSeq; i++) {
+      nextLibrary = strtok(NULL, ";");
+    }
+
+    nextLibrary = strtok(NULL, ";");
+
+    if (NULL == nextLibrary) {
+      printf("KokkosP: No child library to call in %s\n", profileLibrary);
+    } else {
+      printf("KokkosP: Next library to call: %s\n", nextLibrary);
+      printf("KokkosP: Loading child library ..\n");
+
+      handle = dlopen(nextLibrary, RTLD_NOW | RTLD_GLOBAL);
+
+      if (handle == nullptr) {
+        fprintf(stderr, "KokkosP: Error: Unable to load: %s (Error=%s)\n",
+                nextLibrary, dlerror());
+      }
+    }
+
+    free(envBuffer);
+
+    lookup_function(handle, "kokkosp_begin_parallel_scan",
+                    next_events.begin_parallel_scan);
+    lookup_function(handle, "kokkosp_begin_parallel_for",
+                    next_events.begin_parallel_for);
+    lookup_function(handle, "kokkosp_begin_parallel_reduce",
+                    next_events.begin_parallel_reduce);
+    lookup_function(handle, "kokkosp_end_parallel_scan",
+                    next_events.end_parallel_scan);
+    lookup_function(handle, "kokkosp_end_parallel_for",
+                    next_events.end_parallel_for);
+    lookup_function(handle, "kokkosp_end_parallel_reduce",
+                    next_events.end_parallel_reduce);
+
+    lookup_function(handle, "kokkosp_init_library", next_events.init);
+    lookup_function(handle, "kokkosp_finalize_library", next_events.finalize);
+
+    lookup_function(handle, "kokkosp_push_profile_region",
+                    next_events.push_region);
+    lookup_function(handle, "kokkosp_pop_profile_region",
+                    next_events.pop_region);
+    lookup_function(handle, "kokkosp_allocate_data", next_events.allocate_data);
+    lookup_function(handle, "kokkosp_deallocate_data",
+                    next_events.deallocate_data);
+
+    lookup_function(handle, "kokkosp_begin_deep_copy",
+                    next_events.begin_deep_copy);
+    lookup_function(handle, "kokkosp_end_deep_copy", next_events.end_deep_copy);
+    lookup_function(handle, "kokkosp_begin_fence", next_events.begin_fence);
+    lookup_function(handle, "kokkosp_end_fence", next_events.end_fence);
+    lookup_function(handle, "kokkosp_dual_view_sync",
+                    next_events.sync_dual_view);
+    lookup_function(handle, "kokkosp_dual_view_modify",
+                    next_events.modify_dual_view);
+
+    lookup_function(handle, "kokkosp_declare_metadata",
+                    next_events.declare_metadata);
+    lookup_function(handle, "kokkosp_create_profile_section",
+                    next_events.create_profile_section);
+    lookup_function(handle, "kokkosp_start_profile_section",
+                    next_events.start_profile_section);
+    lookup_function(handle, "kokkosp_stop_profile_section",
+                    next_events.stop_profile_section);
+    lookup_function(handle, "kokkosp_destroy_profile_section",
+                    next_events.destroy_profile_section);
+
+    lookup_function(handle, "kokkosp_profile_event", next_events.profile_event);
+
+    lookup_function(handle, "kokkosp_declare_output_type",
+                    next_events.declare_output_type);
+
+    lookup_function(handle, "kokkosp_declare_input_type",
+                    next_events.declare_input_type);
+    lookup_function(handle, "kokkosp_request_values",
+                    next_events.request_output_values);
+    lookup_function(handle, "kokkosp_end_context",
+                    next_events.end_tuning_context);
+    lookup_function(handle, "kokkosp_begin_context",
+                    next_events.begin_tuning_context);
+    lookup_function(handle, "kokkosp_declare_optimization_goal",
+                    next_events.declare_optimization_goal);
+
+    lookup_function(handle, "kokkosp_print_help", next_events.print_help);
+    lookup_function(handle, "kokkosp_parse_args", next_events.parse_args);
+    lookup_function(handle, "kokkosp_transmit_actions",
+                    next_events.transmit_actions);
+    lookup_function(handle, "kokkosp_request_responses",
+                    next_events.request_responses);
+  }
+  void kokkosp_begin_parallel_scan(const char *name, const uint32_t devID,
+                                   uint64_t *kID) {
+    call_kokkos_callback(next_events.begin_parallel_scan, std::true_type{},
+                         name, devID, kID);
+  }
+  void kokkosp_begin_parallel_for(const char *name, const uint32_t devID,
+                                  uint64_t *kID) {
+    call_kokkos_callback(next_events.begin_parallel_for, std::true_type{}, name,
+                         devID, kID);
+  }
+  void kokkosp_begin_parallel_reduce(const char *name, const uint32_t devID,
+                                     uint64_t *kID) {
+    call_kokkos_callback(next_events.begin_parallel_reduce, std::true_type{},
+                         name, devID, kID);
+  }
+  void kokkosp_end_parallel_scan(uint64_t kID) {
+    call_kokkos_callback(next_events.end_parallel_scan, std::true_type{}, kID);
+  }
+  void kokkosp_end_parallel_for(uint64_t kID) {
+    call_kokkos_callback(next_events.end_parallel_for, std::true_type{}, kID);
+  }
+  void kokkosp_end_parallel_reduce(uint64_t kID) {
+    call_kokkos_callback(next_events.end_parallel_reduce, std::true_type{},
+                         kID);
+  }
+  void kokkosp_init_library(int loadseq, uint64_t version, uint32_t ndevinfos,
+                            Kokkos_Profiling_KokkosPDeviceInfo *devInfos) {
+    load_seq = loadseq;
+    call_kokkos_callback(next_events.init, std::false_type{}, loadseq + 1,
+                         version, ndevinfos, devInfos);
+  }
+  void kokkosp_finalize_library() {
+    call_kokkos_callback(next_events.finalize, std::false_type{});
+  }
+  void kokkosp_push_profile_region(const char *name) {
+    call_kokkos_callback(next_events.push_region, std::false_type{}, name);
+  }
+  void kokkosp_pop_profile_region() {
+    call_kokkos_callback(next_events.pop_region, std::false_type{});
+  }
+  void kokkosp_allocate_data(Kokkos::Tools::SpaceHandle handle,
+                             const char *name, void *ptr, uint64_t size) {
+    call_kokkos_callback(next_events.allocate_data, std::false_type{}, handle,
+                         name, ptr, size);
+  }
+  void kokkosp_deallocate_data(Kokkos::Tools::SpaceHandle handle,
+                               const char *name, void *ptr, uint64_t size) {
+    call_kokkos_callback(next_events.deallocate_data, std::false_type{}, handle,
+                         name, ptr, size);
+  }
+  void kokkosp_begin_deep_copy(Kokkos::Tools::SpaceHandle dst_handle,
+                               const char *dst_name, const void *dst_ptr,
+                               Kokkos::Tools::SpaceHandle src_handle,
+                               const char *src_name, const void *src_ptr,
+                               uint64_t size) {
+    call_kokkos_callback(next_events.begin_deep_copy, std::false_type{},
+                         dst_handle, dst_name, dst_ptr, src_handle, src_name,
+                         src_ptr, size);
+  }
+  void kokkosp_end_deep_copy() {
+    call_kokkos_callback(next_events.end_deep_copy, std::false_type{});
+  }
+  void kokkosp_begin_fence(const char *name, const uint32_t devID,
+                           uint64_t *kID) {
+    call_kokkos_callback(next_events.begin_fence, std::false_type{}, name,
+                         devID, kID);
+  }
+  void kokkosp_end_fence(uint64_t kID) {
+    call_kokkos_callback(next_events.end_fence, std::false_type{}, kID);
+  }
+  void kokkosp_dual_view_sync(const char *label, const void *const ptr,
+                              bool to_device) {
+    call_kokkos_callback(next_events.sync_dual_view, std::false_type{}, label,
+                         ptr, to_device);
+  }
+  void kokkosp_dual_view_modify(const char *label, const void *const ptr,
+                                bool to_device) {
+    call_kokkos_callback(next_events.modify_dual_view, std::false_type{}, label,
+                         ptr, to_device);
+  }
+  void kokkosp_declare_metadata(const char *key, const char *value) {
+    call_kokkos_callback(next_events.declare_metadata, std::false_type{}, key,
+                         value);
+  }
+  void kokkosp_create_profile_section(const char *name, uint32_t *sec_id) {
+    call_kokkos_callback(next_events.create_profile_section, std::false_type{},
+                         name, sec_id);
+  }
+  void kokkosp_start_profile_section(uint32_t sec_id) {
+    call_kokkos_callback(next_events.start_profile_section, std::false_type{},
+                         sec_id);
+  }
+  void kokkosp_stop_profile_section(uint32_t sec_id) {
+    call_kokkos_callback(next_events.stop_profile_section, std::false_type{},
+                         sec_id);
+  }
+  void kokkosp_destroy_profile_section(uint32_t sec_id) {
+    call_kokkos_callback(next_events.destroy_profile_section, std::false_type{},
+                         sec_id);
+  }
+  void kokkosp_profile_event(const char *name) {
+    call_kokkos_callback(next_events.profile_event, std::false_type{}, name);
+  }
+  void
+  kokkosp_declare_output_type(const char *name, size_t id,
+                              Kokkos::Tools::Experimental::VariableInfo *info) {
+    call_kokkos_callback(next_events.declare_output_type, std::false_type{},
+                         name, id, info);
+  }
+  void
+  kokkosp_declare_input_type(const char *name, size_t id,
+                             Kokkos::Tools::Experimental::VariableInfo *info) {
+    call_kokkos_callback(next_events.declare_input_type, std::false_type{},
+                         name, id, info);
+  }
+  void kokkosp_request_values(
+      size_t context_id, size_t num_context_values,
+      Kokkos::Tools::Experimental::VariableValue *context_values,
+      size_t num_output_values,
+      Kokkos::Tools::Experimental::VariableValue *output_values) {
+    call_kokkos_callback(next_events.request_output_values, std::false_type{},
+                         context_id, num_context_values, context_values,
+                         num_output_values, output_values);
+  }
+  void kokkosp_end_context(size_t context_id) {
+    call_kokkos_callback(
+        next_events.end_tuning_context, std::false_type{}, context_id,
+        Kokkos::Tools::Experimental::VariableValue{}); // TODO: fix
+  }
+  void kokkosp_begin_context(size_t context_id) {
+    call_kokkos_callback(next_events.begin_tuning_context, std::false_type{},
+                         context_id);
+  }
+  void kokkosp_declare_optimization_goal(
+      size_t context_id, Kokkos::Tools::Experimental::OptimizationGoal goal) {
+    call_kokkos_callback(next_events.declare_optimization_goal,
+                         std::false_type{}, context_id, goal);
+  }
+  void kokkosp_print_help(char *arg0) {
+    call_kokkos_callback(next_events.print_help, std::false_type{}, arg0);
+  }
+  void kokkosp_parse_args(int argc, char **argv) {
+    call_kokkos_callback(next_events.parse_args, std::false_type{}, argc, argv);
+  }
+  void
+  kokkosp_transmit_actions(Kokkos::Tools::Experimental::ToolActions actions) {
+    call_kokkos_callback(next_events.transmit_actions, std::false_type{},
+                         actions);
+  }
+  void kokkosp_request_responses(
+      Kokkos::Tools::Experimental::ToolResponses *responses) {
+    call_kokkos_callback(next_events.request_responses, std::false_type{},
+                         responses);
+  }
+};
+} // namespace Tools
+} // namespace Kokkos


### PR DESCRIPTION
Based on kokkos/kokkos#3812

One hope I have for that design is that our simple tools can be given complex capabilities using "overlays," (a concept I'm shamelessly stealing from @nmhamster  and @jrmadsen ). This PR introduces some infrastructure to enable that concept, and two example overlays.

First, I formalized the process for forwarding your callbacks to a next tool, using a "callback_chainer" struct, which handles loading a next library, grabbing callbacks, all that mess.

The first example overlay is a trivial "passthrough" overlay. All it does is forward events, I basically used it to prove out the callback_chainer thing.

The other is a sampler overlay. This turns off Kokkos global fencing, and then every 101 kernel invocations (that should be a settable parameter) it forwards the kernel to an underlying tool. Fences are only introduced in the case where the kernel is profiled. I've tested this with the space-time-stack and TAU (TAU through modifying tau_exec).

What's neat here is that space-time-stack is completely unmodified, but gets this sampling capability "for free." It's kind of a deeply weird version of a modular tools framework.

Not sure how I feel about this design as a thing to merge, mainly just putting it up as another proof of concept for the Core PR