### PR TITLE
Fix build-all.sh script

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -17,5 +17,13 @@ make -f $ROOT_DIR/profiling/simple-kernel-timer/Makefile
 make -f $ROOT_DIR/profiling/space-time-stack/Makefile
 make -f $ROOT_DIR/profiling/systemtap-connector/Makefile
 make -f $ROOT_DIR/profiling/timemory-connector/Makefile
-make -f $ROOT_DIR/profiling/vtune-connector/Makefile
-make -f $ROOT_DIR/profiling/vtune-focused-connector/Makefile
+if [ -z "${VTUNE_HOME}" ]; then
+  echo ""
+  echo "========================================="
+  echo "Set VTUNE_HOME to build vtune connectors."
+  echo "========================================="
+  echo ""
+else
+  make -f $ROOT_DIR/profiling/vtune-connector/Makefile
+  make -f $ROOT_DIR/profiling/vtune-focused-connector/Makefile
+fi

--- a/profiling/simple-kernel-timer-json/Makefile
+++ b/profiling/simple-kernel-timer-json/Makefile
@@ -2,13 +2,13 @@ CXX=g++
 CXXFLAGS=-O3 -std=c++11 -g
 SHARED_CXXFLAGS=-shared -fPIC
 
-all: kp_kernel_timer.so
+all: kp_kernel_timer_json.so
 
 MAKEFILE_PATH := $(subst Makefile,,$(abspath $(lastword $(MAKEFILE_LIST))))
 
 CXXFLAGS+=-I${MAKEFILE_PATH}
 
-kp_kernel_timer.so: ${MAKEFILE_PATH}kp_kernel_timer.cpp ${MAKEFILE_PATH}kp_kernel_info.h
+kp_kernel_timer_json.so: ${MAKEFILE_PATH}kp_kernel_timer.cpp ${MAKEFILE_PATH}kp_kernel_info.h
 	$(CXX) $(SHARED_CXXFLAGS) $(CXXFLAGS) -o $@ ${MAKEFILE_PATH}kp_kernel_timer.cpp
 
 clean:


### PR DESCRIPTION
Makes sure the json kernel timer doesn't overwrite the normal kernel timer .so and check for VTUNE_HOME being set in the build-all.sh script before attempting to build vtune connectors. 