### PR TITLE
make json output conform to standard

### DIFF
--- a/profiling/simple-kernel-timer-json/kp_kernel_info.h
+++ b/profiling/simple-kernel-timer-json/kp_kernel_info.h
@@ -204,7 +204,7 @@ class KernelPerformanceInfo {
 			fprintf(output, "%s\"time-per-call\"  : %16.8f,\n", indentBuffer, (time /
 				static_cast<double>(std::max(
 					static_cast<uint64_t>(1), callCount))));
-			fprintf(output, "%s\"kernel-type\"    : \"%s\",\n", indentBuffer,
+			fprintf(output, "%s\"kernel-type\"    : \"%s\"\n", indentBuffer,
 				(kType == PARALLEL_FOR) ? "PARALLEL-FOR" :
 				(kType == PARALLEL_REDUCE) ? "PARALLEL-REDUCE" : "PARALLEL-SCAN");
 

--- a/profiling/simple-kernel-timer-json/kp_kernel_timer.cpp
+++ b/profiling/simple-kernel-timer-json/kp_kernel_timer.cpp
@@ -126,7 +126,7 @@ extern "C" void kokkosp_finalize_library() {
 
 	std::sort(kernelList.begin(), kernelList.end(), compareKernelPerformanceInfo);
 
-	fprintf(output_data, "kokkos-kernel-data : {\n");
+	fprintf(output_data, "{\n");
 	fprintf(output_data, "    \"mpi-rank\"               : %s,\n", 
 		(NULL == mpi_rank) ? "0" : mpi_rank);
 	fprintf(output_data, "    \"total-app-time\"         : %10.3f,\n", totalExecuteTime);


### PR DESCRIPTION
The current output does not follow the json standard and cannot be loaded by, for example, the `json` library of `python`.