### PR TITLE
Use NVTX range push/pop instead of start/end in push/pop_profile_region

### DIFF
--- a/profiling/nvprof-connector/kp_nvprof_connector.cpp
+++ b/profiling/nvprof-connector/kp_nvprof_connector.cpp
@@ -51,8 +51,6 @@
 
 #include "nvToolsExt.h"
 
-static std::unordered_map<uint64_t, nvtxRangeId_t> range_map;
-static std::stack<nvtxRangeId_t> region_range_stack;
 static uint64_t nextKernelID;
 
 extern "C" void kokkosp_init_library(const int loadSeq,
@@ -106,18 +104,9 @@ extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
 }
 
 extern "C" void kokkosp_push_profile_region(char* regionName) {
-  nvtxRangeId_t kernelRangeMarker = nvtxRangeStartA(regionName);
-  region_range_stack.push(kernelRangeMarker);
+  nvtxRangePush(regionName);
 }
 
 extern "C" void kokkosp_pop_profile_region() {
-  if (region_range_stack.empty()) {
-    std::cerr
-        << "KokkosP: Error - popped region with no active regions pushed. "
-        << std::endl;
-  } else {
-    auto stack_top = region_range_stack.top();
-    nvtxRangeEnd(stack_top);
-    region_range_stack.pop();
-  }
+  nvtxRangePop();
 }


### PR DESCRIPTION
The current profiling APIs mix nvtxRangePush/Pop and nvtxRangeStart/End. The consequence is that Kokkos View construction and parallel for operations may use a different NVTX API than what the user does with explicit profiling regions in their code, which can be confusing to look at in an Nsight Systems timeline. If everything uses nvtxRangePush() and nvtxRangePop() then all regions should be nicely nested on the timeline. Also, nvtxRangePush() and nvtxRangePop() effectively manage their own stack, so there is no need for kokkos-tools to do this.