### PR TITLE
Add fence events to logger

### DIFF
--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -136,6 +136,22 @@ extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
 	printf("KokkosP: Execution of kernel %llu is completed.\n", kID);
 }
 
+extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint64_t* kID) {
+	*kID = uniqID++;
+
+	printf("KokkosP: Executing fence on device %d with unique execution identifier %llu\n",
+		devID, *kID);
+
+	int level = kokkosp_print_region_stack();
+	kokkosp_print_region_stack_indent(level);
+	
+	printf("%s\n", name);
+}
+
+extern "C" void kokkosp_end_fence(const uint64_t kID) {
+	printf("KokkosP: Execution of fence %llu is completed.\n", kID);
+}
+
 extern "C" void kokkosp_push_profile_region(char* regionName) {
 	printf("KokkosP: Entering profiling region: %s\n", regionName);
 


### PR DESCRIPTION
The kernel-logger tool didn't support fences, it's trivial to allow it to do so