### PR TITLE
Fix systemtap-connector Makefile

### DIFF
--- a/profiling/systemtap-connector/Makefile
+++ b/profiling/systemtap-connector/Makefile
@@ -2,15 +2,15 @@ CXX=g++
 CXXFLAGS=-O3 -std=c++11 -g
 SHARED_CXXFLAGS=-shared -fPIC
 
+MAKEFILE_PATH := $(subst Makefile,,$(abspath $(lastword $(MAKEFILE_LIST))))
+
 all: kp_systemtap_connector.so
 
-probes.h: ${MAKEFILE_PATH}probes.d
+${MAKEFILE_PATH}probes.h: ${MAKEFILE_PATH}probes.d
 	dtrace -C -h -s $< -o $@
 
 probes.o: ${MAKEFILE_PATH}probes.d
 	dtrace -C -G -s $< -o $@
-
-MAKEFILE_PATH := $(subst Makefile,,$(abspath $(lastword $(MAKEFILE_LIST))))
 
 CXXFLAGS+=-I${MAKEFILE_PATH}
 


### PR DESCRIPTION
Fixed path matching bug that caused GNU Make 4.2.1 fail on Ubuntu 20.04 with error:
```shell
make: *** No rule to make target '..../kokkos-tools/profiling/systemtap-connector/probes.h',
          needed by 'kp_systemtap_connector.so'.  Stop.
```