### PR TITLE
Disable global fencing for nvprof_connector tool.

### DIFF
--- a/profiling/nvprof-connector/Makefile
+++ b/profiling/nvprof-connector/Makefile
@@ -9,7 +9,6 @@ all: kp_nvprof_connector.so
 MAKEFILE_PATH := $(subst Makefile,,$(abspath $(lastword $(MAKEFILE_LIST))))
 
 CXXFLAGS+=-I${MAKEFILE_PATH}
-CXXFLAGS+=-I${KOKKOS_ROOT}/include
 
 kp_nvprof_connector.so: ${MAKEFILE_PATH}kp_nvprof_connector.cpp
 	$(CXX) $(SHARED_CXXFLAGS) $(CXXFLAGS) $(LDFLAGS) \

--- a/profiling/nvprof-connector/Makefile
+++ b/profiling/nvprof-connector/Makefile
@@ -9,6 +9,7 @@ all: kp_nvprof_connector.so
 MAKEFILE_PATH := $(subst Makefile,,$(abspath $(lastword $(MAKEFILE_LIST))))
 
 CXXFLAGS+=-I${MAKEFILE_PATH}
+CXXFLAGS+=-I${KOKKOS_ROOT}/include
 
 kp_nvprof_connector.so: ${MAKEFILE_PATH}kp_nvprof_connector.cpp
 	$(CXX) $(SHARED_CXXFLAGS) $(CXXFLAGS) $(LDFLAGS) \

--- a/profiling/nvprof-connector/kp_nvprof_connector.cpp
+++ b/profiling/nvprof-connector/kp_nvprof_connector.cpp
@@ -50,6 +50,11 @@
 #include <iostream>
 
 #include "nvToolsExt.h"
+#include "impl/Kokkos_Profiling_C_Interface.h"
+
+extern "C" void kokkosp_request_tool_settings(const uint32_t, Kokkos_Tools_ToolSettings* settings) {
+  settings->requires_global_fencing = false;
+}
 
 static uint64_t nextKernelID;
 

--- a/profiling/nvprof-connector/kp_nvprof_connector.cpp
+++ b/profiling/nvprof-connector/kp_nvprof_connector.cpp
@@ -50,7 +50,12 @@
 #include <iostream>
 
 #include "nvToolsExt.h"
-#include "impl/Kokkos_Profiling_C_Interface.h"
+
+struct Kokkos_Tools_ToolSettings
+{
+  bool requires_global_fencing;
+  bool padding[255];
+};
 
 extern "C" void kokkosp_request_tool_settings(const uint32_t, Kokkos_Tools_ToolSettings* settings) {
   settings->requires_global_fencing = false;


### PR DESCRIPTION
Since nvprof/nsys can appropriately time kernels without the fences
and it is desirable to be able to use them to investigate how well kernel
overlapping is working.