### PR TITLE
Makefile for kp_samper.cpp

### DIFF
--- a/profiling/ldms-kokkos-sampler/Makefile
+++ b/profiling/ldms-kokkos-sampler/Makefile
@@ -1,0 +1,26 @@
+OVIS_DIR=/projects/ovis/streams/opt/ovis
+
+CXX=g++
+CXXFLAGS=-O3 -std=c++11 -g \
+        -I$(OVIS_DIR)/include/ -I./include
+SHARED_CXXFLAGS=-shared -fPIC
+LDFLAGS=-L$(OVIS_DIR)/lib
+LIBS=-lldmsd_stream -lldms -lrt
+
+all: kp_kernel_ldms.so
+
+MAKEFILE_PATH := $(subst Makefile,,$(abspath $(lastword $(MAKEFILE_LIST))))
+
+CXXFLAGS+=-I${MAKEFILE_PATH}
+
+kp_kernel_ldms.so: ${MAKEFILE_PATH}kp_kernel_ldms.cpp ${MAKEFILE_PATH}kp_kernel_info.h
+	$(CXX) $(SHARED_CXXFLAGS) $(CXXFLAGS) $(LDFLAGS) -o $@ ${MAKEFILE_PATH}kp_kernel_ldms.cpp \
+	$(LIBS)
+
+kp_sampler.so: ${MAKEFILE_PATH}kp_sampler.cpp ${MAKEFILE_PATH}kp_kernel_info.h
+	$(CXX) $(SHARED_CXXFLAGS) $(CXXFLAGS) $(LDFLAGS) -o $@ ${MAKEFILE_PATH}kp_sampler.cpp \
+	$(LIBS)
+
+
+clean:
+	rm *.so


### PR DESCRIPTION
Adding the Makefile that is associated with appropriately compiling the kp_sampler.cpp file for the LDMS-Kokkos sampler.