### PR TITLE
Fixing indents of Kokkos fences in Debugger 

### DIFF
--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -138,8 +138,10 @@ extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
 
 extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint64_t* kID) {
 	*kID = uniqID++;
+	
+	kokkosp_print_region_stack_indent(1);
 
-	printf("KokkosP: Executing fence on device %d with unique execution identifier %llu\n",
+	printf("Executing fence on device %d with unique execution identifier %llu\n",
 		devID, *kID);
 
 	int level = kokkosp_print_region_stack();
@@ -148,8 +150,10 @@ extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint
 	printf("%s\n", name);
 }
 
-extern "C" void kokkosp_end_fence(const uint64_t kID) {
-	printf("KokkosP: Execution of fence %llu is completed.\n", kID);
+extern "C" void kokkosp_end_fence(const uint64_t kID) { 
+	
+	kokkosp_print_region_stack_indent(1);
+	printf("Execution of fence %llu is completed.\n", kID);
 }
 
 extern "C" void kokkosp_push_profile_region(char* regionName) {

--- a/profiling/memory-hwm-mpi/kp_hwm_mpi.cpp
+++ b/profiling/memory-hwm-mpi/kp_hwm_mpi.cpp
@@ -71,7 +71,7 @@ extern "C" void kokkosp_init_library(const int loadSeq,
   MPI_Comm_size(MPI_COMM_WORLD, &world_size);
 
   if (world_rank == 0) {
-    printf("KokkosP: Example Library Initialized (sequence is %d, version: %" PRIu64 ")\n", loadSeq, interfaceVer);
+    printf("KokkosP: High Water Mark Library Initialized (sequence is %d, version: %" PRIu64 ")\n", loadSeq, interfaceVer);
   }
 }
 


### PR DESCRIPTION
Indents for debugger prints of each Kokkos::Fence call so that a user can easily identify/group the printed output for each fence more easily.