### PR TITLE
Fixes to filter out undesirable fences 

### DIFF
--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -156,7 +156,7 @@ extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint
 }
 
 extern "C" void kokkosp_end_fence(const uint64_t kID) {
-       if(! (kID == std::numeric_limits<uint64_t>::max() )
+       if(kID != std::numeric_limits<uint64_t>::max() ) 
 	printf("KokkosP: Execution of fence %llu is completed.\n", kID);
 }
 

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -97,7 +97,7 @@ extern "C" void kokkosp_begin_parallel_for(const char* name, const uint32_t devI
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf("%s\n", name);
+	printf(" %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_for(const uint64_t kID) {
@@ -113,7 +113,7 @@ extern "C" void kokkosp_begin_parallel_scan(const char* name, const uint32_t dev
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf("%s\n", name);
+	printf(" %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_scan(const uint64_t kID) {
@@ -129,7 +129,7 @@ extern "C" void kokkosp_begin_parallel_reduce(const char* name, const uint32_t d
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf("%s\n", name);
+	printf(" %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
@@ -145,7 +145,7 @@ extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf("%s\n", name);
+	printf(" %s\n", name);
 }
 
 extern "C" void kokkosp_end_fence(const uint64_t kID) {

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -97,7 +97,7 @@ extern "C" void kokkosp_begin_parallel_for(const char* name, const uint32_t devI
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf(" %s\n", name);
+	printf("    %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_for(const uint64_t kID) {
@@ -113,7 +113,7 @@ extern "C" void kokkosp_begin_parallel_scan(const char* name, const uint32_t dev
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf(" %s\n", name);
+	printf("    %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_scan(const uint64_t kID) {
@@ -129,7 +129,7 @@ extern "C" void kokkosp_begin_parallel_reduce(const char* name, const uint32_t d
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf(" %s\n", name);
+	printf("    %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
@@ -145,7 +145,7 @@ extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf(" %s\n", name);
+	printf("    %s\n", name);
 }
 
 extern "C" void kokkosp_end_fence(const uint64_t kID) {

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -137,7 +137,7 @@ extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
 }
 
 extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint64_t* kID) {
-	 if (std::stristr(name, "fence")) { // filter out fence as this is a duplicate and unneeded (causing the tool to hinder performance of application). We use strstr for checking if the string contains the label of a fence (we assume the user will always have the word fence in the label of the fence).  
+	 if (std::strstr(name, "Kokkos Profile Tool Fence")) { // filter out fence as this is a duplicate and unneeded (causing the tool to hinder performance of application). We use strstr for checking if the string contains the label of a fence (we assume the user will always have the word fence in the label of the fence).  
               *kID = std::numeric_limits<uint64_t>::max(); // set the dereferenced execution identifier to be the maximum value of uint64_t, which is assumed to never be assigned
            }
         else {
@@ -156,6 +156,7 @@ extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint
 extern "C" void kokkosp_end_fence(const uint64_t kID) { 
        if(kID != std::numeric_limits<uint64_t>::max()) { // if we find the kID to be maximum value uint64_t, then the callback is dealing with the application's fence, which we filtered out in the callback for fences 
 	printf("KokkosP: Execution of fence %llu is completed.\n", kID); 
+       }
 }
 
 extern "C" void kokkosp_push_profile_region(char* regionName) {

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -156,6 +156,7 @@ extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint
 }
 
 extern "C" void kokkosp_end_fence(const uint64_t kID) {
+       if(! (kID == std::numeric_limits<uint64_t>::max() )
 	printf("KokkosP: Execution of fence %llu is completed.\n", kID);
 }
 

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -137,10 +137,17 @@ extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
 }
 
 extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint64_t* kID) {
-	*kID = uniqID++;
+		
+	 if (std::strstr(name, "Kokkos Profile Tool Fence"))
+           {
+              *kID = std::numeric_limits<uint64_t>::max();
+           }
+        else
+          {
+          *kID = uniqID++;
 
-	printf("KokkosP: Executing fence on device %d with unique execution identifier %llu\n",
-		devID, *kID);
+        printf("KokkosP: Executing fence on device %d with unique execution identifier %llu\n",
+                devID, *kID);
 
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -55,7 +55,7 @@ struct SpaceHandle {
 
 void kokkosp_print_region_stack_indent(const int level) {
 	printf("KokkosP: ");
-	
+
 	for(int i = 0; i < level; i++) {
 		printf("  ");
 	}
@@ -79,7 +79,7 @@ extern "C" void kokkosp_init_library(const int loadSeq,
 	const uint32_t devInfoCount,
 	void* deviceInfo) {
 
-	printf("KokkosP: Example Library Initialized (sequence is %d, version: %llu)\n", loadSeq, interfaceVer);
+	printf("KokkosP: Kernel Logger Library Initialized (sequence is %d, version: %llu)\n", loadSeq, interfaceVer);
 	uniqID = 0;
 	
 }

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -137,7 +137,7 @@ extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
 }
 
 extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint64_t* kID) {
-	 if (std::strstr(name, "fence")) { // filter out fence as this is a duplicate and unneeded (causing the tool to hinder performance of application). We use strstr for checking if the string contains the label of a fence (we assume the user will always have the word fence in the label of the fence).  
+	 if (std::stristr(name, "fence")) { // filter out fence as this is a duplicate and unneeded (causing the tool to hinder performance of application). We use strstr for checking if the string contains the label of a fence (we assume the user will always have the word fence in the label of the fence).  
               *kID = std::numeric_limits<uint64_t>::max(); // set the dereferenced execution identifier to be the maximum value of uint64_t, which is assumed to never be assigned
            }
         else {

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -137,13 +137,10 @@ extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
 }
 
 extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint64_t* kID) {
-		
-	 if (std::strstr(name, "Kokkos Profile Tool Fence"))
-           {
-              *kID = std::numeric_limits<uint64_t>::max();
+	 if (std::strstr(name, "fence")) { // filter out fence as this is a duplicate and unneeded (causing the tool to hinder performance of application). We use strstr for checking if the string contains the label of a fence (we assume the user will always have the word fence in the label of the fence).  
+              *kID = std::numeric_limits<uint64_t>::max(); // set the dereferenced execution identifier to be the maximum value of uint64_t, which is assumed to never be assigned
            }
-        else
-          {
+        else {
           *kID = uniqID++;
 
         printf("KokkosP: Executing fence on device %d with unique execution identifier %llu\n",
@@ -153,11 +150,12 @@ extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint
 	kokkosp_print_region_stack_indent(level);
 	
 	printf("    %s\n", name);
+	} 
 }
 
-extern "C" void kokkosp_end_fence(const uint64_t kID) {
-       if(kID != std::numeric_limits<uint64_t>::max() ) 
-	printf("KokkosP: Execution of fence %llu is completed.\n", kID);
+extern "C" void kokkosp_end_fence(const uint64_t kID) { 
+       if(kID != std::numeric_limits<uint64_t>::max()) { // if we find the kID to be maximum value uint64_t, then the callback is dealing with the application's fence, which we filtered out in the callback for fences 
+	printf("KokkosP: Execution of fence %llu is completed.\n", kID); 
 }
 
 extern "C" void kokkosp_push_profile_region(char* regionName) {

--- a/profiling/memory-hwm-mpi/kp_hwm_mpi.cpp
+++ b/profiling/memory-hwm-mpi/kp_hwm_mpi.cpp
@@ -71,7 +71,7 @@ extern "C" void kokkosp_init_library(const int loadSeq,
   MPI_Comm_size(MPI_COMM_WORLD, &world_size);
 
   if (world_rank == 0) {
-    printf("KokkosP: Example Library Initialized (sequence is %d, version: %" PRIu64 ")\n", loadSeq, interfaceVer);
+    printf("KokkosP: High Water Mark Library Initialized (sequence is %d, version: %" PRIu64 ")\n", loadSeq, interfaceVer);
   }
 }
 

--- a/profiling/memory-hwm/kp_hwm.cpp
+++ b/profiling/memory-hwm/kp_hwm.cpp
@@ -61,7 +61,7 @@ extern "C" void kokkosp_init_library(const int loadSeq,
 	const uint32_t devInfoCount,
 	void* deviceInfo) {
 
-	printf("KokkosP: Example Library Initialized (sequence is %d, version: %llu)\n", loadSeq, interfaceVer);
+	printf("KokkosP: High Water Mark Library Initialized (sequence is %d, version: %llu)\n", loadSeq, interfaceVer);
 }
 
 // darwin report rusage.ru_maxrss in bytes

--- a/profiling/nvprof-connector/kp_nvprof_connector.cpp
+++ b/profiling/nvprof-connector/kp_nvprof_connector.cpp
@@ -42,6 +42,8 @@
 
 #include <cstdio>
 #include <cstdint>
+#include <vector>
+#include <string>
 
 #include "nvToolsExt.h"
 
@@ -114,3 +116,29 @@ extern "C" void kokkosp_push_profile_region(char* regionName) {
 extern "C" void kokkosp_pop_profile_region() {
   nvtxRangePop();
 }
+
+namespace {
+struct Section {
+        std::string label;
+        nvtxRangeId_t id;
+};
+std::vector<Section> kokkosp_sections;
+}  // namespace
+
+extern "C" void kokkosp_create_profile_section(const char* name,
+                                               uint32_t* sID) {
+        *sID = kokkosp_sections.size();
+        kokkosp_sections.push_back(
+            {std::string(name), static_cast<nvtxRangeId_t>(-1)});
+}
+
+extern "C" void kokkosp_start_profile_section(const uint32_t sID) {
+        auto& section = kokkosp_sections[sID];
+        section.id = nvtxRangeStartA(section.label.c_str());
+}
+
+extern "C" void kokkosp_stop_profile_section(const uint32_t sID) {
+        auto const& section = kokkosp_sections[sID];
+        nvtxRangeEnd(section.id);
+}
+

--- a/profiling/nvprof-connector/kp_nvprof_connector.cpp
+++ b/profiling/nvprof-connector/kp_nvprof_connector.cpp
@@ -40,14 +40,8 @@
 // ************************************************************************
 //@HEADER
 
-#include <stdio.h>
-#include <inttypes.h>
-#include <cstdlib>
-#include <cstring>
-#include <unordered_map>
-#include <stack>
-#include <string>
-#include <iostream>
+#include <cstdio>
+#include <cstdint>
 
 #include "nvToolsExt.h"
 

--- a/profiling/nvprof-connector/kp_nvprof_connector.cpp
+++ b/profiling/nvprof-connector/kp_nvprof_connector.cpp
@@ -119,26 +119,26 @@ extern "C" void kokkosp_pop_profile_region() {
 
 namespace {
 struct Section {
-        std::string label;
-        nvtxRangeId_t id;
+  std::string label;
+  nvtxRangeId_t id;
 };
 std::vector<Section> kokkosp_sections;
 }  // namespace
 
 extern "C" void kokkosp_create_profile_section(const char* name,
                                                uint32_t* sID) {
-        *sID = kokkosp_sections.size();
-        kokkosp_sections.push_back(
-            {std::string(name), static_cast<nvtxRangeId_t>(-1)});
+  *sID = kokkosp_sections.size();
+  kokkosp_sections.push_back(
+    {std::string(name), static_cast<nvtxRangeId_t>(-1)});
 }
 
 extern "C" void kokkosp_start_profile_section(const uint32_t sID) {
-        auto& section = kokkosp_sections[sID];
-        section.id = nvtxRangeStartA(section.label.c_str());
+  auto& section = kokkosp_sections[sID];
+  section.id = nvtxRangeStartA(section.label.c_str());
 }
 
 extern "C" void kokkosp_stop_profile_section(const uint32_t sID) {
-        auto const& section = kokkosp_sections[sID];
-        nvtxRangeEnd(section.id);
+  auto const& section = kokkosp_sections[sID];
+  nvtxRangeEnd(section.id);
 }
 

--- a/profiling/roctx-connector/Makefile
+++ b/profiling/roctx-connector/Makefile
@@ -1,5 +1,5 @@
 CXX=g++
-CXXFLAGS=-O3 -g -I$(ROCM_PATH)/roctracer/include
+CXXFLAGS=-O3 -g -I$(ROCM_PATH)/include/roctracer
 LDFLAGS=-L$(ROCM_PATH)/lib
 LIBS=-lroctx64
 SHARED_CXXFLAGS=-shared -fPIC

--- a/profiling/roctx-connector/kp_roctx_connector.cpp
+++ b/profiling/roctx-connector/kp_roctx_connector.cpp
@@ -55,6 +55,18 @@ struct Section {
 std::vector<Section> kokkosp_sections;
 }  // namespace
 
+
+struct Kokkos_Tools_ToolSettings
+{
+        bool requires_global_fencing;
+        bool padding[255];
+};
+
+extern "C" void kokkosp_request_tool_settings(const uint32_t,
+                                              Kokkos_Tools_ToolSettings* settings) {
+        settings->requires_global_fencing = false;
+}
+
 extern "C" void kokkosp_init_library(const int loadSeq,
                                      const uint64_t interfaceVer,
                                      const uint32_t /*devInfoCount*/,

--- a/profiling/roctx-connector/kp_roctx_connector.cpp
+++ b/profiling/roctx-connector/kp_roctx_connector.cpp
@@ -146,3 +146,13 @@ extern "C" void kokkosp_stop_profile_section(const uint32_t sID) {
 extern "C" void kokkosp_destroy_profile_section(const uint32_t sID) {
         // do nothing
 }
+
+extern "C" void kokkosp_begin_fence(const char* name,
+		                    const uint32_t /*devID*/,
+		                    uint64_t* fID) {
+        *fID = roctxRangeStart(name);
+}
+
+extern "C" void kokkosp_end_fence(const uint64_t fID) {
+        roctxRangeStop(fID);
+}

--- a/profiling/simple-kernel-timer/kp_kernel_timer.cpp
+++ b/profiling/simple-kernel-timer/kp_kernel_timer.cpp
@@ -117,7 +117,7 @@ extern "C" void kokkosp_init_library(const int loadSeq,
 	// initialize regions to 0s so we know if there is an object there
 	memset(&regions[0], 0, 512 * sizeof(KernelPerformanceInfo*));
 
-	printf("KokkosP: Example Library Initialized (sequence is %d, version: %llu)\n", loadSeq, interfaceVer);
+	printf("KokkosP: Simple Kernel Timer Library Initialized (sequence is %d, version: %llu)\n", loadSeq, interfaceVer);
 
 	initTime = seconds();
 }


### PR DESCRIPTION
# Change Made

Fix to invocation of extraneous fences and associated prints at the beginning of fence (kokkosp_begin_fence()) and the ending fence (kokkosp_end_fence()) for the Kokkos debugger tool. This is needed to filter out undesirable fences induced by the debugger, as discussed in Kokkos tools github Issue #147. 

If the name of the function (kernel identifier, represented as the uint64_t kID) the debugger tool is profiling is itself a fence, we filter out the application's fence by setting kId to std::numeric_limits<uint64_t>::max(). 



# Sample Output / Demonstration 

Considering the Kokkos stream benchmark using the kokkos tools logger (note this is without PR #153):

## Before change
The following is done on a macosX with clang++ version 14.0.0. 

```
export KOKKOS_TOOLS_LIBS=${KokkosProjectHOME}/kokkos-tools/debugging/kernel-logger/kp_kernel_logger.so; ./stream.exe

-------------------------------------------------------------
Kokkos STREAM Benchmark
-------------------------------------------------------------
KokkosP: Example Library Initialized (sequence is 0, version: 20211015)
Reports fastest timing per kernel
Creating Views...
Memory Sizes:
- Array Size:    100000000
- Per Array:           800.00 MB
- Total:              2400.00 MB
Benchmark kernels will be performed for 20 iterations.
-------------------------------------------------------------
KokkosP: Allocate<Host> name: a pointer: 0x12ae00040 size: 800000000
KokkosP: Executing fence on device 100663296 with unique execution identifier 0
KokkosP: Kokkos::Tools::invoke_kokkosp_callback: Kokkos Profile Tool Fence
KokkosP: Execution of fence 0 is completed.
KokkosP: Executing parallel-for kernel on device 100663297 with unique execution identifier 1
KokkosP: Kokkos::View::initialization [a] via memset
KokkosP: Executing fence on device 100663297 with unique execution identifier 2
KokkosP: HostSpace fence
KokkosP: Execution of fence 2 is completed.
KokkosP: Executing fence on device 100663296 with unique execution identifier 3
KokkosP: Kokkos::Tools::invoke_kokkosp_callback: Kokkos Profile Tool Fence
KokkosP: Execution of fence 3 is completed.
KokkosP: Execution of kernel 1 is completed.
KokkosP: Executing fence on device 100663297 with unique execution identifier 4
KokkosP: Kokkos::Impl::ViewValueFunctor: View init/destroy fence
KokkosP: Execution of fence 4 is completed.

...

Performing validation...
All solutions checked and verified.
-------------------------------------------------------------
Set                62583.32 MB/s
Copy               81260.04 MB/s
Scale              80542.82 MB/s
Add                81323.77 MB/s
Triad              80843.01 MB/s
-------------------------------------------------------------
KokkosP: Executing fence on device 100663296 with unique execution identifier 525
KokkosP:  HostSpace::impl_deallocate before free
KokkosP: Execution of fence 525 is completed.
KokkosP: Deallocate<Host> name: c pointer: 0x2afaf4040 size: 800000000
KokkosP: Executing fence on device 100663296 with unique execution identifier 526
KokkosP:  HostSpace::impl_deallocate before free
KokkosP: Execution of fence 526 is completed.
KokkosP: Deallocate<Host> name: b pointer: 0x280000040 size: 800000000
KokkosP: Executing fence on device 100663296 with unique execution identifier 527
KokkosP:  HostSpace::impl_deallocate before free
KokkosP: Execution of fence 527 is completed.
KokkosP: Deallocate<Host> name: a pointer: 0x107e00040 size: 800000000
KokkosP: Kokkos library finalization called.

```

 ## After change

```
export CMAKE_CXX_STANDARD=14; export KOKKOS_TOOLS_LIBS=/Users/csuadmin/Desktop/ViveksLaptop/wk/wk/code/kokkosProject/kokkos-tools-new/debugging/kernel-logger/kp_kernel_logger.so; ./stream.exe 
-------------------------------------------------------------
Kokkos STREAM Benchmark
-------------------------------------------------------------
KokkosP: Example Library Initialized (sequence is 0, version: 20211015)
Reports fastest timing per kernel
Creating Views...
Memory Sizes:
- Array Size:    100000000
- Per Array:           800.00 MB
- Total:              2400.00 MB
Benchmark kernels will be performed for 20 iterations.
-------------------------------------------------------------
KokkosP: Allocate<Host> name: a pointer: 0x128800040 size: 800000000
KokkosP: Executing parallel-for kernel on device 100663297 with unique execution identifier 0
KokkosP: Kokkos::View::initialization [a] via memset
KokkosP: Executing fence on device 100663297 with unique execution identifier 1
KokkosP: HostSpace fence
KokkosP: Execution of fence 1 is completed.
KokkosP: Execution of kernel 0 is completed.

....


Performing validation...
All solutions checked and verified.
-------------------------------------------------------------
Set                62439.84 MB/s
Copy               80293.91 MB/s
Scale              80096.78 MB/s
Add                80883.20 MB/s
Triad              79857.70 MB/s
-------------------------------------------------------------
KokkosP: Executing fence on device 100663296 with unique execution identifier 317
KokkosP: HostSpace::impl_deallocate before free
KokkosP: Execution of fence 317 is completed.
KokkosP: Deallocate<Host> name: c pointer: 0x2afaf4040 size: 800000000
KokkosP: Executing fence on device 100663296 with unique execution identifier 318
KokkosP: HostSpace::impl_deallocate before free
KokkosP: Execution of fence 318 is completed.
KokkosP: Deallocate<Host> name: b pointer: 0x280000040 size: 800000000
KokkosP: Executing fence on device 100663296 with unique execution identifier 319
KokkosP: HostSpace::impl_deallocate before free
KokkosP: Execution of fence 319 is completed.
KokkosP: Deallocate<Host> name: a pointer: 0x128800040 size: 800000000
KokkosP: Kokkos library finalization called. 

```

Note that compared to the "Before" case, in the "After" case: 
1.  the tool induced fences are filtered out 
2. the unique execution identifier ID  ends at 319 rather than 527 

Also, for this test, the performance, i.e., bandwidth numbers at the end of the output, of the second is not significantly different (within measurement error) from that of the first. We expect that in a larger run and a run on a GPU rather than CPU that performance will improve with this fix. 