### PR TITLE
Indent names in logger

### DIFF
--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -97,7 +97,7 @@ extern "C" void kokkosp_begin_parallel_for(const char* name, const uint32_t devI
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf("%s\n", name);
+	printf(" %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_for(const uint64_t kID) {
@@ -113,7 +113,7 @@ extern "C" void kokkosp_begin_parallel_scan(const char* name, const uint32_t dev
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf("%s\n", name);
+	printf(" %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_scan(const uint64_t kID) {
@@ -129,7 +129,7 @@ extern "C" void kokkosp_begin_parallel_reduce(const char* name, const uint32_t d
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf("%s\n", name);
+	printf(" %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
@@ -145,7 +145,7 @@ extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf("%s\n", name);
+	printf(" %s\n", name);
 }
 
 extern "C" void kokkosp_end_fence(const uint64_t kID) {

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -97,7 +97,7 @@ extern "C" void kokkosp_begin_parallel_for(const char* name, const uint32_t devI
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf(" %s\n", name);
+	printf("    %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_for(const uint64_t kID) {
@@ -113,7 +113,7 @@ extern "C" void kokkosp_begin_parallel_scan(const char* name, const uint32_t dev
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf(" %s\n", name);
+	printf("    %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_scan(const uint64_t kID) {
@@ -129,7 +129,7 @@ extern "C" void kokkosp_begin_parallel_reduce(const char* name, const uint32_t d
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf(" %s\n", name);
+	printf("    %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
@@ -145,7 +145,7 @@ extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf(" %s\n", name);
+	printf("    %s\n", name);
 }
 
 extern "C" void kokkosp_end_fence(const uint64_t kID) {

--- a/profiling/memory-hwm-mpi/kp_hwm_mpi.cpp
+++ b/profiling/memory-hwm-mpi/kp_hwm_mpi.cpp
@@ -71,7 +71,7 @@ extern "C" void kokkosp_init_library(const int loadSeq,
   MPI_Comm_size(MPI_COMM_WORLD, &world_size);
 
   if (world_rank == 0) {
-    printf("KokkosP: Example Library Initialized (sequence is %d, version: %" PRIu64 ")\n", loadSeq, interfaceVer);
+    printf("KokkosP: High Water Mark Library Initialized (sequence is %d, version: %" PRIu64 ")\n", loadSeq, interfaceVer);
   }
 }
 


### PR DESCRIPTION

# Summary of Change Made

This is a simple change for a better visual output of the kernel logger.

Each Kokkos region's label that is printed by the logger ought to be easily identified. A space is added in front each label identified by the variable 'name' for each Kokkos function having a tool callback in the code file debugging/kernel-logger/kp_kernel_logger.cpp. 

# Demonstration of Fix 

The following demonstrates this fix by showing a sample before / after ouput. The Kokkos Stream benchmark with 20 trials is run with clang++ on a  Mac OSX.

## Before Change


```
export KOKKOS_TOOLS_LIBS=${KokkosProjectHOME}/kokkos-tools/debugging/kernel-logger/kp_kernel_logger.so; ./stream.exe 
-------------------------------------------------------------
Kokkos STREAM Benchmark
-------------------------------------------------------------
KokkosP: Example Library Initialized (sequence is 0, version: 20211015)
Reports fastest timing per kernel
Creating Views...
Memory Sizes:
- Array Size:    100000000
- Per Array:           800.00 MB
- Total:              2400.00 MB
Benchmark kernels will be performed for 20 iterations.
-------------------------------------------------------------
KokkosP: Allocate<Host> name: a pointer: 0x12ae00040 size: 800000000
KokkosP: Executing fence on device 100663296 with unique execution identifier 0
KokkosP: Kokkos::Tools::invoke_kokkosp_callback: Kokkos Profile Tool Fence
KokkosP: Execution of fence 0 is completed.
KokkosP: Executing parallel-for kernel on device 100663297 with unique execution identifier 1
KokkosP: Kokkos::View::initialization [a] via memset
KokkosP: Executing fence on device 100663297 with unique execution identifier 2
KokkosP: HostSpace fence
KokkosP: Execution of fence 2 is completed.
KokkosP: Executing fence on device 100663296 with unique execution identifier 3
KokkosP: Kokkos::Tools::invoke_kokkosp_callback: Kokkos Profile Tool Fence
KokkosP: Execution of fence 3 is completed.
KokkosP: Execution of kernel 1 is completed.
KokkosP: Executing fence on device 100663297 with unique execution identifier 4
KokkosP: Kokkos::Impl::ViewValueFunctor: View init/destroy fence
KokkosP: Execution of fence 4 is completed.

```
## After Change

```
bash-5.1$ export KOKKOS_TOOLS_LIBS=${KokkosProjectHOME}/kokkos-tools/myBuild/debugging/kernel-logger/kp_kernel_logger.so; ./stream.exe
-------------------------------------------------------------
Kokkos STREAM Benchmark
-------------------------------------------------------------
KokkosP: Example Library Initialized (sequence is 0, version: 20211015)
Reports fastest timing per kernel
Creating Views...
Memory Sizes:
- Array Size:    100000000
- Per Array:           800.00 MB
- Total:              2400.00 MB
Benchmark kernels will be performed for 20 iterations.
-------------------------------------------------------------
KokkosP: Allocate<Host> name: a pointer: 0x112e00040 size: 800000000
KokkosP: Executing fence on device 100663296 with unique execution identifier 0
KokkosP:  Kokkos::Tools::invoke_kokkosp_callback: Kokkos Profile Tool Fence
KokkosP: Execution of fence 0 is completed.
KokkosP: Executing parallel-for kernel on device 100663297 with unique execution identifier 1
KokkosP:  Kokkos::View::initialization [a] via memset
KokkosP: Executing fence on device 100663297 with unique execution identifier 2
KokkosP:  HostSpace fence
KokkosP: Execution of fence 2 is completed.
KokkosP: Executing fence on device 100663296 with unique execution identifier 3
KokkosP:  Kokkos::Tools::invoke_kokkosp_callback: Kokkos Profile Tool Fence
KokkosP: Execution of fence 3 is completed.
KokkosP: Execution of kernel 1 is completed.
KokkosP: Executing fence on device 100663297 with unique execution identifier 4
KokkosP:  Kokkos::Impl::ViewValueFunctor: View init/destroy fence
KokkosP: Execution of fence 4 is completed.

```

It is expected to work on any platform; any inconsistencies with the above ouput on other platforms will be tracked and fixed accordingly. No change to performance or correctness is expected on any platform. 

This PR does not include the fix to filter out undesirable (tool-induced) fences from PR #152.
