### PR TITLE
Filter undesirable fences (PR against develop branch)

### DIFF
--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -121,27 +121,38 @@ extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
   printf("KokkosP: Execution of kernel %llu is completed.\n", kID);
 }
 
-extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint64_t* kID) {
-	 if (std::strstr(name, "Kokkos Profile Tool Fence")) { // filter out fence as this is a duplicate and unneeded (causing the tool to hinder performance of application). We use strstr for checking if the string contains the label of a fence (we assume the user will always have the word fence in the label of the fence).  
-              *kID = std::numeric_limits<uint64_t>::max(); // set the dereferenced execution identifier to be the maximum value of uint64_t, which is assumed to never be assigned
-           }
-        else {
-          *kID = uniqID++;
+extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID,
+                                    uint64_t* kID) {
+  // filter out fence as this is a duplicate and unneeded (causing the tool to
+  // hinder performance of application). We use strstr for checking if the
+  // string contains the label of a fence (we assume the user will always have
+  // the word fence in the label of the fence).
+  if (std::strstr(name, "Kokkos Profile Tool Fence")) {
+    // set the dereferenced execution identifier to be the maximum value of
+    // uint64_t, which is assumed to never be assigned
+    *kID = std::numeric_limits<uint64_t>::max();
+  } else {
+    *kID = uniqID++;
 
-        printf("KokkosP: Executing fence on device %d with unique execution identifier %llu\n",
-                devID, *kID);
+    printf(
+        "KokkosP: Executing fence on device %d with unique execution "
+        "identifier %llu\n",
+        devID, *kID);
 
-	int level = kokkosp_print_region_stack();
-	kokkosp_print_region_stack_indent(level);
-	
-	printf("    %s\n", name);
-	} 
+    int level = kokkosp_print_region_stack();
+    kokkosp_print_region_stack_indent(level);
+
+    printf("    %s\n", name);
+  }
 }
 
-extern "C" void kokkosp_end_fence(const uint64_t kID) { 
-       if(kID != std::numeric_limits<uint64_t>::max()) { // if we find the kID to be maximum value uint64_t, then the callback is dealing with the application's fence, which we filtered out in the callback for fences 
-	printf("KokkosP: Execution of fence %llu is completed.\n", kID); 
-       }
+extern "C" void kokkosp_end_fence(const uint64_t kID) {
+  // if we find the kID to be maximum value uint64_t, then the callback is
+  // dealing with the application's fence, which we filtered out in the callback
+  // for fences
+  if (kID != std::numeric_limits<uint64_t>::max()) {
+    printf("KokkosP: Execution of fence %llu is completed.\n", kID);
+  }
 }
 
 extern "C" void kokkosp_push_profile_region(char* regionName) {

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -141,7 +141,7 @@ extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint
 }
 
 extern "C" void kokkosp_end_fence(const uint64_t kID) {
-       if(! (kID == std::numeric_limits<uint64_t>::max() )
+       if(kID != std::numeric_limits<uint64_t>::max() ) 
 	printf("KokkosP: Execution of fence %llu is completed.\n", kID);
 }
 

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -122,7 +122,7 @@ extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
 }
 
 extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint64_t* kID) {
-	 if (std::strstr(name, "fence")) { // filter out fence as this is a duplicate and unneeded (causing the tool to hinder performance of application). We use strstr for checking if the string contains the label of a fence (we assume the user will always have the word fence in the label of the fence).  
+	 if (std::stristr(name, "fence")) { // filter out fence as this is a duplicate and unneeded (causing the tool to hinder performance of application). We use strstr for checking if the string contains the label of a fence (we assume the user will always have the word fence in the label of the fence).  
               *kID = std::numeric_limits<uint64_t>::max(); // set the dereferenced execution identifier to be the maximum value of uint64_t, which is assumed to never be assigned
            }
         else {

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -122,27 +122,25 @@ extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
 }
 
 extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint64_t* kID) {
-		
-	 if (std::strstr(name, "Kokkos Profile Tool Fence"))
-           {
-              *kID = std::numeric_limits<uint64_t>::max();
+	 if (std::strstr(name, "fence")) { // filter out fence as this is a duplicate and unneeded (causing the tool to hinder performance of application). We use strstr for checking if the string contains the label of a fence (we assume the user will always have the word fence in the label of the fence).  
+              *kID = std::numeric_limits<uint64_t>::max(); // set the dereferenced execution identifier to be the maximum value of uint64_t, which is assumed to never be assigned
            }
-        else
-          {
+        else {
           *kID = uniqID++;
 
         printf("KokkosP: Executing fence on device %d with unique execution identifier %llu\n",
                 devID, *kID);
 
-  int level = kokkosp_print_region_stack();
-  kokkosp_print_region_stack_indent(level);
-
-  printf("    %s\n", name);
+	int level = kokkosp_print_region_stack();
+	kokkosp_print_region_stack_indent(level);
+	
+	printf("    %s\n", name);
+	} 
 }
 
-extern "C" void kokkosp_end_fence(const uint64_t kID) {
-       if(kID != std::numeric_limits<uint64_t>::max() ) 
-	printf("KokkosP: Execution of fence %llu is completed.\n", kID);
+extern "C" void kokkosp_end_fence(const uint64_t kID) { 
+       if(kID != std::numeric_limits<uint64_t>::max()) { // if we find the kID to be maximum value uint64_t, then the callback is dealing with the application's fence, which we filtered out in the callback for fences 
+	printf("KokkosP: Execution of fence %llu is completed.\n", kID); 
 }
 
 extern "C" void kokkosp_push_profile_region(char* regionName) {

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -141,7 +141,8 @@ extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint
 }
 
 extern "C" void kokkosp_end_fence(const uint64_t kID) {
-  printf("KokkosP: Execution of fence %llu is completed.\n", kID);
+       if(! (kID == std::numeric_limits<uint64_t>::max() )
+	printf("KokkosP: Execution of fence %llu is completed.\n", kID);
 }
 
 extern "C" void kokkosp_push_profile_region(char* regionName) {

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -122,7 +122,7 @@ extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
 }
 
 extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint64_t* kID) {
-	 if (std::stristr(name, "fence")) { // filter out fence as this is a duplicate and unneeded (causing the tool to hinder performance of application). We use strstr for checking if the string contains the label of a fence (we assume the user will always have the word fence in the label of the fence).  
+	 if (std::strstr(name, "Kokkos Profile Tool Fence")) { // filter out fence as this is a duplicate and unneeded (causing the tool to hinder performance of application). We use strstr for checking if the string contains the label of a fence (we assume the user will always have the word fence in the label of the fence).  
               *kID = std::numeric_limits<uint64_t>::max(); // set the dereferenced execution identifier to be the maximum value of uint64_t, which is assumed to never be assigned
            }
         else {
@@ -141,6 +141,7 @@ extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint
 extern "C" void kokkosp_end_fence(const uint64_t kID) { 
        if(kID != std::numeric_limits<uint64_t>::max()) { // if we find the kID to be maximum value uint64_t, then the callback is dealing with the application's fence, which we filtered out in the callback for fences 
 	printf("KokkosP: Execution of fence %llu is completed.\n", kID); 
+       }
 }
 
 extern "C" void kokkosp_push_profile_region(char* regionName) {

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -121,14 +121,18 @@ extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
   printf("KokkosP: Execution of kernel %llu is completed.\n", kID);
 }
 
-extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID,
-                                    uint64_t* kID) {
-  *kID = uniqID++;
+extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint64_t* kID) {
+		
+	 if (std::strstr(name, "Kokkos Profile Tool Fence"))
+           {
+              *kID = std::numeric_limits<uint64_t>::max();
+           }
+        else
+          {
+          *kID = uniqID++;
 
-  printf(
-      "KokkosP: Executing fence on device %d with unique execution identifier "
-      "%llu\n",
-      devID, *kID);
+        printf("KokkosP: Executing fence on device %d with unique execution identifier %llu\n",
+                devID, *kID);
 
   int level = kokkosp_print_region_stack();
   kokkosp_print_region_stack_indent(level);


### PR DESCRIPTION
This is a fix to filter undesirable fences based on the current PR #152 against master. That PR should be redirect to this PR right now. (That PR was mistakenly opened against master and should have been against develop branch first as per procedure.) The below is a copy-paste of the description of that PR. 


# Change Made
If the name of the function (kernel identifier, represented as the uint64_t kID) the debugger tool is profiling is itself a fence, we filter out the application's fence by setting kId to std::numeric_limits<uint64_t>::max().  

Note that this specifically addresses sub-issue 2 in Github Issue #147 but a solution/test to filter out fences for sub-issue 1 (where tool-induced fences should be filtered out so that state/behavior of the profiling or debugging tool isn't affected) has not been performed. A patch to this PR - or another PR -  will be added soon which provides modification/enhancement to this PR's solution to assure fences don't cause unintended behavior of associated debugging/profiling tools.



# Sample Output / Demonstration 

Considering the Kokkos stream benchmark using the kokkos tools logger (note this is without PR #153):

## Before change
The following is done on a macosX with clang++ version 14.0.0. 

```
export KOKKOS_TOOLS_LIBS=${KokkosProjectHOME}/kokkos-tools/debugging/kernel-logger/kp_kernel_logger.so; ./stream.exe

-------------------------------------------------------------
Kokkos STREAM Benchmark
-------------------------------------------------------------
KokkosP: Example Library Initialized (sequence is 0, version: 20211015)
Reports fastest timing per kernel
Creating Views...
Memory Sizes:
- Array Size:    100000000
- Per Array:           800.00 MB
- Total:              2400.00 MB
Benchmark kernels will be performed for 20 iterations.
-------------------------------------------------------------
KokkosP: Allocate<Host> name: a pointer: 0x12ae00040 size: 800000000
KokkosP: Executing fence on device 100663296 with unique execution identifier 0
KokkosP: Kokkos::Tools::invoke_kokkosp_callback: Kokkos Profile Tool Fence
KokkosP: Execution of fence 0 is completed.
KokkosP: Executing parallel-for kernel on device 100663297 with unique execution identifier 1
KokkosP: Kokkos::View::initialization [a] via memset
KokkosP: Executing fence on device 100663297 with unique execution identifier 2
KokkosP: HostSpace fence
KokkosP: Execution of fence 2 is completed.
KokkosP: Executing fence on device 100663296 with unique execution identifier 3
KokkosP: Kokkos::Tools::invoke_kokkosp_callback: Kokkos Profile Tool Fence
KokkosP: Execution of fence 3 is completed.
KokkosP: Execution of kernel 1 is completed.
KokkosP: Executing fence on device 100663297 with unique execution identifier 4
KokkosP: Kokkos::Impl::ViewValueFunctor: View init/destroy fence
KokkosP: Execution of fence 4 is completed.

...

Performing validation...
All solutions checked and verified.
-------------------------------------------------------------
Set                62583.32 MB/s
Copy               81260.04 MB/s
Scale              80542.82 MB/s
Add                81323.77 MB/s
Triad              80843.01 MB/s
-------------------------------------------------------------
KokkosP: Executing fence on device 100663296 with unique execution identifier 525
KokkosP:  HostSpace::impl_deallocate before free
KokkosP: Execution of fence 525 is completed.
KokkosP: Deallocate<Host> name: c pointer: 0x2afaf4040 size: 800000000
KokkosP: Executing fence on device 100663296 with unique execution identifier 526
KokkosP:  HostSpace::impl_deallocate before free
KokkosP: Execution of fence 526 is completed.
KokkosP: Deallocate<Host> name: b pointer: 0x280000040 size: 800000000
KokkosP: Executing fence on device 100663296 with unique execution identifier 527
KokkosP:  HostSpace::impl_deallocate before free
KokkosP: Execution of fence 527 is completed.
KokkosP: Deallocate<Host> name: a pointer: 0x107e00040 size: 800000000
KokkosP: Kokkos library finalization called.

```

 ## After change

```
export CMAKE_CXX_STANDARD=14; export KOKKOS_TOOLS_LIBS=/Users/csuadmin/Desktop/ViveksLaptop/wk/wk/code/kokkosProject/kokkos-tools-new/debugging/kernel-logger/kp_kernel_logger.so; ./stream.exe 
-------------------------------------------------------------
Kokkos STREAM Benchmark
-------------------------------------------------------------
KokkosP: Example Library Initialized (sequence is 0, version: 20211015)
Reports fastest timing per kernel
Creating Views...
Memory Sizes:
- Array Size:    100000000
- Per Array:           800.00 MB
- Total:              2400.00 MB
Benchmark kernels will be performed for 20 iterations.
-------------------------------------------------------------
KokkosP: Allocate<Host> name: a pointer: 0x128800040 size: 800000000
KokkosP: Executing parallel-for kernel on device 100663297 with unique execution identifier 0
KokkosP: Kokkos::View::initialization [a] via memset
KokkosP: Executing fence on device 100663297 with unique execution identifier 1
KokkosP: HostSpace fence
KokkosP: Execution of fence 1 is completed.
KokkosP: Execution of kernel 0 is completed.

....


Performing validation...
All solutions checked and verified.
-------------------------------------------------------------
Set                62439.84 MB/s
Copy               80293.91 MB/s
Scale              80096.78 MB/s
Add                80883.20 MB/s
Triad              79857.70 MB/s
-------------------------------------------------------------
KokkosP: Executing fence on device 100663296 with unique execution identifier 317
KokkosP: HostSpace::impl_deallocate before free
KokkosP: Execution of fence 317 is completed.
KokkosP: Deallocate<Host> name: c pointer: 0x2afaf4040 size: 800000000
KokkosP: Executing fence on device 100663296 with unique execution identifier 318
KokkosP: HostSpace::impl_deallocate before free
KokkosP: Execution of fence 318 is completed.
KokkosP: Deallocate<Host> name: b pointer: 0x280000040 size: 800000000
KokkosP: Executing fence on device 100663296 with unique execution identifier 319
KokkosP: HostSpace::impl_deallocate before free
KokkosP: Execution of fence 319 is completed.
KokkosP: Deallocate<Host> name: a pointer: 0x128800040 size: 800000000
KokkosP: Kokkos library finalization called. 

```

Note that compared to the "Before" case, in the "After" case: 
1.  the tool induced fences are filtered out 
2. the unique execution identifier ID  ends at 319 rather than 527 

Also, for this test, the performance, i.e., bandwidth numbers at the end of the output, of the second is not significantly different (within measurement error) from that of the first. We expect that in a larger run and a run on a GPU rather than CPU that performance will improve with this fix. 
