### PR TITLE
Improved readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Note: `Kokkos_ENABLE_LIBDL` must be on to load profiling hooks dynamically. It s
 
 ## General Usage
 
- To use one of the tools you have to compile it, which will generate a dynamic library. Before executing the Kokkos application you then have to set the environment variable `KOKKOS_PROFILE_LIBRARY` to point to the dynamic libary e.g. in Bash:
+ To use one of the tools you have to compile it, which will generate a dynamic library. Before executing the Kokkos application you then have to set the environment variable `KOKKOS_PROFILE_LIBRARY` to point to the dynamic library e.g. in Bash:
 ```
 export KOKKOS_PROFILE_LIBRARY=${HOME}/kokkos-tools/src/tools/memory-events/kp_memory_event.so
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Note: `Kokkos_ENABLE_LIBDL` must be on to load profiling hooks dynamically. It s
 export KOKKOS_PROFILE_LIBRARY=${HOME}/kokkos-tools/src/tools/memory-events/kp_memory_event.so
 ```
 
-Many of the tools will produce an output file which uses the hostname as well as the process id as part of the filename. 
+Many of the tools will produce an output file that uses the hostname as well as the process id as part of the filename. 
 
 ## Explicit Instrumentation
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,58 @@
-# KokkosP Profiling Tools
+# KokkosP Profiling Tools 
+
+## What 
 Performance profiling tools that can be optionally integrated into Kokkos-based applications and libraries.
+
+
+## Why 
+- Generally, understanding performance and correctness of Kokkos programs in a performance portable way. How do we do apples-to-apples comparison for detailed profiling? 
+- Name demangling from backend tools output
+- Uniform interface for backend tools, e.g., NVprof, Rocprof
+
+## Examples of existing tools: 
+
+### Performance Profiling
+- SimpleKernelTimer 
+- SpaceTimeStack
+
+### Debugging
+- kp_reader
+- kp_kernel_logger
+- kp_kernel_filter
+
+# Using this Software 
+## Build Kokkos tools 
+
+To build all the tools, simply create a build directory and type `cmake ..` in it. You can configure the cmake options through `ccmake ..`.  Doing so is not recommended. The build has been tested sucessfully on Perlmutter and MacOS.
+
+## Making Kokkos Application code invoke Kokkos tools
+
+Use Kokkos pushRegion and popRegion surrounding regions that you want to profile on. 
+
+## Running a Kokkos-based Application with a tool 
+
+Given your tool _<name_of_tool>_ (which contains kokkos profiling callback functions) and an application executable called yourApplication.exe, type 
+export KOKKOS_TOOL_LIB=${YOUR_KOKKOS_TOOLS_DIR}/libkp_<name_of_tool>.dylib; ./yourApplication.exe
+
+
+# Notes for Developers
+- Kokkos callback functions, e.g., kokkosp_callback_fence(..) are inserted through binary instrumentation of the application. 
+- Developing your own connector is possible. 
+- The new cmake build process is being tested on various machines in the DoE. Avoid building with systemtap-connector when using cmake. 
+- An alternate 'make' build process is still available in the master branch. 
+- Each Kokkos tool is dynamic libraries when building via cmake (dylib) but a shared object (.so) file when using a Makefile to build. 
+
+
+# Documentation
+
+https://github.com/kokkos/kokkos-tutorials/blob/main/LectureSeries/KokkosTutorial_07_Tools.pdf
+
+
+# Contact 
+
+* Vivek Kale (vlkale@sandia.gov)
+* Christian Trott (crtrott@sandia.gov) 
+
+# Acknowledgement
+
+Special thanks to David Poliakoff on earlier work on tools development.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Note: `Kokkos` must be configured with `Kokkos_ENABLE_LIBDL=ON` to load profilin
 
 ## General Usage
 
- To use one of the tools you have to compile it, which will generate a dynamic library. Before executing the Kokkos application you then have to set the environment variable `KOKKOS_PROFILE_LIBRARY` to point to the dynamic library e.g. in Bash:
+ To use one of the tools you have to compile it, which will generate a dynamic library. Before executing the Kokkos application you then have to set the environment variable `KOKKOS_TOOLS_LIB` to point to the dynamic library e.g. in Bash:
 ```
 export KOKKOS_PROFILE_LIBRARY=${HOME}/kokkos-tools/src/tools/memory-events/kp_memory_event.so
 ```
@@ -54,11 +54,11 @@ void foo() {
 ### Kernel Inspection
 + **[[SimpleKernelTimer|SimpleKernelTimer]]:**
 
-    Captures Basic Timing information for Kernels.
+    Captures basic timing information for Kernels.
 
 + **[[KernelLogger|KernelLogger]]:**
 
-    Prints Kernel and Region events during runtime.
+    Prints kernel and region events during runtime.
 
 ### 3rd Party Profiling Tool Hooks
 + **[[VTuneConnector|VTuneConnector]]:**
@@ -82,7 +82,7 @@ void foo() {
     resource usage, etc. 
 
 
-# Building Kokkos-tools
+# Building Kokkos Tools
 
 Use either cmake or provided Makefile within each tools directory. 
 
@@ -90,9 +90,9 @@ Building with Makefiles is currently recommended.
 
 # Running a Kokkos-based Application with a tool
 
-Given your tool shared library <name_of_tool_shared_library>.so (which contains kokkos profiling callback functions) and an application executable called yourApplication.exe, type 
+Given your tool shared library <name_of_tool_shared_library>.so (which contains kokkos profiling callback functions) and an application executable called yourApplication.exe, type: 
 
-`export KOKKOS_PROFILE_LIBRARY=${YOUR_KOKKOS_TOOLS_DIR}/<name_of_tool_shared_lib>; ./yourApplication.exe`
+`export KOKKOS_TOOLS_LIB=${YOUR_KOKKOS_TOOLS_DIR}/<name_of_tool_shared_lib>; ./yourApplication.exe 
 
 # Documentation
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 # Kokkos Tools
 
-Kokkos Tools provide a light-weight set of profiling and debugging utilities, which interface with instrumentation hooks built directly into the Kokkos runtime. Compared to 3rd party tools these tools can provide much cleaner, context specific information: in particular, they allow kernel centric analysis and they use labels provided to Kokkos objects (kernel launches and views).
+Kokkos Tools provide a light-weight set of profiling and debugging utilities, which interface with instrumentation hooks built directly into the Kokkos runtime. Compared to 3rd party tools these tools can provide much cleaner, context-specific information: in particular, they allow kernel-centric analysis and they use labels provided to Kokkos objects (kernel launches and views).
 
-Under most circumstances the profiling hooks are compiled into Kokkos executables by default. That means the tools work for your existing Kokkos applications, assuming that the profiling hooks version is compatible with the tools version. No recompilation or changes to your build procedures are required.
+Under most circumstances, the profiling hooks are compiled into Kokkos executables by default assuming that the profiling hooks' version is compatible with the tools' version. No recompilation or changes to your build procedures are required.
 
-Note: `Kokkos_ENABLE_LIBDL` must be on to load profiling hooks dynamically. It should be on by default however.
+Note: `Kokkos` must be configured with `Kokkos_ENABLE_LIBDL=ON` to load profiling hooks dynamically. This is the default for most cases anyway.
 
 ## General Usage
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ Building with Makefiles is currently recommended.
 
 
 
-Given your tool shared library <name_of_tool_shared_library>.so (which contains kokkos profiling callback functions) and an application executable called yourApplication.exe, type export KOKKOS_TOOL_LIB=${YOUR_KOKKOS_TOOLS_DIR}/<name_of_tool_shared_lib>; ./yourApplication.exe
+Given your tool shared library <name_of_tool_shared_library>.so (which contains kokkos profiling callback functions) and an application executable called yourApplication.exe, type 
+
+`export KOKKOS_PROFILE_LIBRARY=${YOUR_KOKKOS_TOOLS_DIR}/<name_of_tool_shared_lib>; ./yourApplication.exe`
 
 
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ void foo() {
 
 + **[[KernelFilter|KernelFilter]]:**
 
-   A tool which is used in conjunction with analysis tools, to restrict them to a subset of the application.
+   A tool that is used in conjunction with analysis tools, to restrict them to a subset of the application.
 
 ### Memory Analysis
 + **[[MemoryHighWater|MemoryHighWater]]:**

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ void foo() {
 
 # Building Kokkos Tools
 
-Use either cmake or provided Makefile within each tools directory. 
+Use either CMake or provided Makefile within each subdirectory of Kokkos Tools.
 
 Building with Makefiles is currently recommended. 
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Note: `Kokkos_ENABLE_LIBDL` must be on to load profiling hooks dynamically. It s
 
 ## General Usage
 
-To use one of the tools you have to compile it, which will generate a dynamic library. Before executing the Kokkos application you then have to set the environment variable `KOKKOS_PROFILE_LIBRARY` to point to the dynamic libary e.g. in Bash:
+ To use one of the tools you have to compile it, which will generate a dynamic library. Before executing the Kokkos application you then have to set the environment variable `KOKKOS_PROFILE_LIBRARY` to point to the dynamic libary e.g. in Bash:
 ```
 export KOKKOS_PROFILE_LIBRARY=${HOME}/kokkos-tools/src/tools/memory-events/kp_memory_event.so
 ```
@@ -36,7 +36,7 @@ void foo() {
 
 + **[[KernelFilter|KernelFilter]]:**
 
-    A tool which is used in conjunction with analysis tools, to restrict them to a subset of the application.
+   A tool which is used in conjunction with analysis tools, to restrict them to a subset of the application.
 
 ### Memory Analysis
 + **[[MemoryHighWater|MemoryHighWater]]:**
@@ -84,12 +84,20 @@ void foo() {
 
 # Building Kokkos-tools
 
-To build all the tools, simply create a build directory and type cmake .. in it. You can configure the cmake options through ccmake ... Doing so is not recommended. The build has been tested sucessfully on Perlmutter and MacOS.
+Use either cmake or provided Makefile within each tools directory. 
 
+Building with Makefiles is currently recommended. 
 
 # Running a Kokkos-based Application with a tool
 
-Given your tool <name_of_tool> (which contains kokkos profiling callback functions) and an application executable called yourApplication.exe, type export KOKKOS_TOOL_LIB=${YOUR_KOKKOS_TOOLS_DIR}/libkp_<name_of_tool>.dylib; ./yourApplication.exe
+
+
+Given your tool shared library <name_of_tool_shared_library>.so (which contains kokkos profiling callback functions) and an application executable called yourApplication.exe, type export KOKKOS_TOOL_LIB=${YOUR_KOKKOS_TOOLS_DIR}/<name_of_tool_shared_lib>; ./yourApplication.exe
+
+
+
+
+
 # Documentation
 
 Further information and tutorials can be found here: https://github.com/kokkos/kokkos-tutorials/blob/main/LectureSeries/KokkosTutorial_07_Tools.pdf

--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ void foo() {
     resource usage, etc. 
 
 
+# Building Kokkos-tools
+
+To build all the tools, simply create a build directory and type cmake .. in it. You can configure the cmake options through ccmake ... Doing so is not recommended. The build has been tested sucessfully on Perlmutter and MacOS.
+
+
+# Running a Kokkos-based Application with a tool
+
+Given your tool <name_of_tool> (which contains kokkos profiling callback functions) and an application executable called yourApplication.exe, type export KOKKOS_TOOL_LIB=${YOUR_KOKKOS_TOOLS_DIR}/libkp_<name_of_tool>.dylib; ./yourApplication.exe
 # Documentation
 
 Further information and tutorials can be found here: https://github.com/kokkos/kokkos-tutorials/blob/main/LectureSeries/KokkosTutorial_07_Tools.pdf

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ void foo() {
     
     Provides Kernel Names to VTune, so that analysis can be performed on a per kernel base.
 
-+ [[VTuneFocusedConnector|VTuneFocusedConnector]]
++ **[[VTuneFocusedConnector|VTuneFocusedConnector]]**
     
     Like VTuneConnector but turns profiling off outside of kernels. Should be used in conjunction with the KernelFilter tool. 
 

--- a/README.md
+++ b/README.md
@@ -1,57 +1,96 @@
-# KokkosP Profiling Tools 
-
-## What 
-Performance profiling tools that can be optionally integrated into Kokkos-based applications and libraries.
 
 
-## Why 
-- Generally, understanding performance and correctness of Kokkos programs in a performance portable way. How do we do apples-to-apples comparison for detailed profiling? 
-- Name demangling from backend tools output
-- Uniform interface for backend tools, e.g., NVprof, Rocprof
+# Kokkos Tools
 
-## Examples of existing tools: 
+Kokkos Tools provide a light weight set of profiling and debug utilities, which interface with instrumentation hooks built directly into the Kokkos runtime. Compared to 3rd party tools these tools can provide much cleaner, context specific information: in particular, they allow kernel centric analysis and they use labels provided to Kokkos objects (kernel launches and views).
 
-### Performance Profiling
-- SimpleKernelTimer 
-- SpaceTimeStack
+Under most circumstances the profiling hooks are compiled into Kokkos executables by default. That means the tools work for your existing Kokkos applications, assuming that the profiling hooks version is compatible with the tools version. No recompilation or changes to your build procedures are required.
 
-### Debugging
-- kp_reader
-- kp_kernel_logger
-- kp_kernel_filter
+Note: `Kokkos_ENABLE_LIBDL` must be on to load profiling hooks dynamically. It should be on by default however.
 
-# Using this Software 
-## Build Kokkos tools 
+## General Usage
 
-To build all the tools, simply create a build directory and type `cmake ..` in it. You can configure the cmake options through `ccmake ..`.  Doing so is not recommended. The build has been tested sucessfully on Perlmutter and MacOS.
+To use one of the tools you have to compile it, which will generate a dynamic library. Before executing the Kokkos application you then have to set the environment variable `KOKKOS_PROFILE_LIBRARY` to point to the dynamic libary e.g. in Bash:
+```
+export KOKKOS_PROFILE_LIBRARY=${HOME}/kokkos-tools/src/tools/memory-events/kp_memory_event.so
+```
 
-## Making Kokkos Application code invoke Kokkos tools
+Many of the tools will produce an output file which uses the hostname as well as the process id as part of the filename. 
 
-Use Kokkos pushRegion and popRegion surrounding regions that you want to profile on. 
+## Explicit Instrumentation
 
-## Running a Kokkos-based Application with a tool 
+One can explicitly add instrumentation to a library or an application. Currently the only hooks intended for explicit programmer use are the Region related hooks. These use a push/pop model to mark coarser regions in your code.
 
-Given your tool _<name_of_tool>_ (which contains kokkos profiling callback functions) and an application executable called yourApplication.exe, type 
-export KOKKOS_TOOL_LIB=${YOUR_KOKKOS_TOOLS_DIR}/libkp_<name_of_tool>.dylib; ./yourApplication.exe
+```c++
+void foo() {
+   Kokkos::Profiling::pushRegion("foo");
+   bar();
+   stool();
+   Kokkos::Profiling::popRegion();
+}
+```
 
+## Tools
 
-# Notes for Developers
-- Kokkos callback functions, e.g., kokkosp_callback_fence(..) are inserted through binary instrumentation of the application. 
-- Developing your own connector is possible. 
-- The new cmake build process is being tested on various machines in the DoE. Avoid building with systemtap-connector when using cmake. 
-- An alternate 'make' build process is still available in the master branch. 
-- Each Kokkos tool is dynamic libraries when building via cmake (dylib) but a shared object (.so) file when using a Makefile to build. 
+### Utilities
+
++ **[[KernelFilter|KernelFilter]]:**
+
+    A tool which is used in conjunction with analysis tools, to restrict them to a subset of the application.
+
+### Memory Analysis
++ **[[MemoryHighWater|MemoryHighWater]]:**
+
+    Outputs high water mark of memory usage of the application.
+
++ **[[MemoryUsage|MemoryUsage]]:**
+
+    Generates a per Memory Space timeline of memory utilization. 
+
++ **[[MemoryEvents|MemoryEvents]]:** 
+
+    Tool to track memory events such as allocation and deallocation. It also provides the information of the MemoryUsage tool.
+
+### Kernel Inspection
++ **[[SimpleKernelTimer|SimpleKernelTimer]]:**
+
+    Captures Basic Timing information for Kernels.
+
++ **[[KernelLogger|KernelLogger]]:**
+
+    Prints Kernel and Region events during runtime.
+
+### 3rd Party Profiling Tool Hooks
++ **[[VTuneConnector|VTuneConnector]]:**
+    
+    Provides Kernel Names to VTune, so that analysis can be performed on a per kernel base.
+
++ **[[VTuneFocusedConnector|VTuneFocusedConnector]]:**
+    
+    Like VTuneConnector but turns profiling off outside of kernels. Should be used in conjunction with the KernelFilter tool. 
+
++ **[[Timemory|Timemory]]:**
+
+    Modular connector for accumulating timing, memory usage, hardware counters, and other various metrics.
+    Supports controlling VTune, CUDA profilers, and TAU + kernel name forwarding to VTune, NVTX, TAU,
+    Caliper, and LIKWID.
+
+    #####  If you need to write your own plug-in, this provides a straight-forward API to writing the plug-in.
+
+    Defining a timemory component will enable your plug-in to output to stdout, text, and JSON, 
+    accumulate statistics, and utilize various portable function calls for common needs w.r.t. timers,
+    resource usage, etc. 
 
 
 # Documentation
 
-https://github.com/kokkos/kokkos-tutorials/blob/main/LectureSeries/KokkosTutorial_07_Tools.pdf
+Further information and tutorials can be found here: https://github.com/kokkos/kokkos-tutorials/blob/main/LectureSeries/KokkosTutorial_07_Tools.pdf
 
 
 # Contact 
 
 * Vivek Kale (vlkale@sandia.gov)
-* Christian Trott (crtrott@sandia.gov) 
+* Christian Trott (crtrott@sandia.gov)
 
 # Acknowledgement
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Note: `Kokkos` must be configured with `Kokkos_ENABLE_LIBDL=ON` to load profilin
 
  To use one of the tools you have to compile it, which will generate a dynamic library. Before executing the Kokkos application you then have to set the environment variable `KOKKOS_TOOLS_LIB` to point to the dynamic library e.g. in Bash:
 ```
-export KOKKOS_PROFILE_LIBRARY=${HOME}/kokkos-tools/src/tools/memory-events/kp_memory_event.so
+export KOKKOS_TOOLS_LIB=${HOME}/kokkos-tools/src/tools/memory-events/kp_memory_event.so
 ```
 
 Many of the tools will produce an output file that uses the hostname as well as the process id as part of the filename. 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Many of the tools will produce an output file which uses the hostname as well as
 
 ## Explicit Instrumentation
 
-One can explicitly add instrumentation to a library or an application. Currently the only hooks intended for explicit programmer use are the Region related hooks. These use a push/pop model to mark coarser regions in your code.
+One can explicitly add instrumentation to a library or an application. Currently, the only hooks intended for explicit programmer use are the Region related hooks. These use a push/pop model to mark coarser regions in your code.
 
 ```c++
 void foo() {

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ void foo() {
     
     Provides Kernel Names to VTune, so that analysis can be performed on a per kernel base.
 
-+ **[[VTuneFocusedConnector|VTuneFocusedConnector]]:**
++ [[VTuneFocusedConnector|VTuneFocusedConnector]]
     
     Like VTuneConnector but turns profiling off outside of kernels. Should be used in conjunction with the KernelFilter tool. 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Kokkos Tools
 
-Kokkos Tools provide a light weight set of profiling and debug utilities, which interface with instrumentation hooks built directly into the Kokkos runtime. Compared to 3rd party tools these tools can provide much cleaner, context specific information: in particular, they allow kernel centric analysis and they use labels provided to Kokkos objects (kernel launches and views).
+Kokkos Tools provide a light-weight set of profiling and debugging utilities, which interface with instrumentation hooks built directly into the Kokkos runtime. Compared to 3rd party tools these tools can provide much cleaner, context specific information: in particular, they allow kernel centric analysis and they use labels provided to Kokkos objects (kernel launches and views).
 
 Under most circumstances the profiling hooks are compiled into Kokkos executables by default. That means the tools work for your existing Kokkos applications, assuming that the profiling hooks version is compatible with the tools version. No recompilation or changes to your build procedures are required.
 

--- a/README.md
+++ b/README.md
@@ -90,15 +90,9 @@ Building with Makefiles is currently recommended.
 
 # Running a Kokkos-based Application with a tool
 
-
-
 Given your tool shared library <name_of_tool_shared_library>.so (which contains kokkos profiling callback functions) and an application executable called yourApplication.exe, type 
 
 `export KOKKOS_PROFILE_LIBRARY=${YOUR_KOKKOS_TOOLS_DIR}/<name_of_tool_shared_lib>; ./yourApplication.exe`
-
-
-
-
 
 # Documentation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Kokkos Tools
 
-Kokkos Tools provide a light-weight set of profiling and debugging utilities, which interface with instrumentation hooks built directly into the Kokkos runtime. Compared to 3rd party tools these tools can provide much cleaner, context-specific information: in particular, they allow kernel-centric analysis and they use labels provided to Kokkos objects (kernel launches and views).
+Kokkos Tools provide a light-weight set of profiling and debugging utilities, which interface with instrumentation hooks built directly into the Kokkos runtime. Compared to 3rd party tools these tools can provide much cleaner, context-specific information: in particular, they allow kernel-centric analysis and they use labels provided to Kokkos constructs (kernel launches and views).
 
 Under most circumstances, the profiling hooks are compiled into Kokkos executables by default assuming that the profiling hooks' version is compatible with the tools' version. No recompilation or changes to your build procedures are required.
 


### PR DESCRIPTION
Fix #154. 

This is a PR for a significantly improved README, and it should be consistent with the kokkos-tools wiki installation and build instructions for Kokkos tools. Much of it is actually a direct copy-paste, with some more specifics on the repo and very basic cmake build instructions and explanation on how to link and run with Kokkos tools. The README should be updated every 3-4 months and synch'd with the kokkos-tools wiki installation and build instructions. 