### PR TITLE
Missing header includes in kernel-logger

### DIFF
--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -18,6 +18,8 @@
 #include <inttypes.h>
 #include <vector>
 #include <string>
+#include <limits>
+#include <cstring>
 
 std::vector<std::string> regions;
 static uint64_t uniqID;


### PR DESCRIPTION
Without the headers:
```
g++ -shared -fPIC -O3 -std=c++11 -g -o kp_kernel_logger.so /path/to/kokkos-tools/debugging/kernel-logger/kp_kernel_logger.cpp
/path/to/kokkos-tools/debugging/kernel-logger/kp_kernel_logger.cpp: In function 'void kokkosp_begin_fence(const char*, uint32_t, uint64_t*)':
/path/to/kokkos-tools/debugging/kernel-logger/kp_kernel_logger.cpp:130:12: error: 'strstr' is not a member of 'std'
  130 |   if (std::strstr(name, "Kokkos Profile Tool Fence")) {
      |            ^~~~~~
/path/to/kokkos-tools/debugging/kernel-logger/kp_kernel_logger.cpp:133:17: error: 'numeric_limits' is not a member of 'std'
  133 |     *kID = std::numeric_limits<uint64_t>::max();
      |                 ^~~~~~~~~~~~~~
/path/to/kokkos-tools/debugging/kernel-logger/kp_kernel_logger.cpp:133:40: error: expected primary-expression before '>' token
  133 |     *kID = std::numeric_limits<uint64_t>::max();
      |                                        ^
/path/to/kokkos-tools/debugging/kernel-logger/kp_kernel_logger.cpp:133:43: error: '::max' has not been declared; did you mean 'std::max'?
  133 |     *kID = std::numeric_limits<uint64_t>::max();
      |                                           ^~~
      |                                           std::max
In file included from /autofs/nccs-svm1_sw/summit/gcc/10.2.0-2/include/c++/10.2.0/vector:60,
                 from /path/to/kokkos-tools/debugging/kernel-logger/kp_kernel_logger.cpp:19:
/autofs/nccs-svm1_sw/summit/gcc/10.2.0-2/include/c++/10.2.0/bits/stl_algobase.h:300:5: note: 'std::max' declared here
  300 |     max(const _Tp& __a, const _Tp& __b, _Compare __comp)
      |     ^~~
/path/to/kokkos-tools/debugging/kernel-logger/kp_kernel_logger.cpp: In function 'void kokkosp_end_fence(uint64_t)':
/path/to/kokkos-tools/debugging/kernel-logger/kp_kernel_logger.cpp:153:19: error: 'numeric_limits' is not a member of 'std'
  153 |   if (kID != std::numeric_limits<uint64_t>::max()) {
      |                   ^~~~~~~~~~~~~~
/path/to/kokkos-tools/debugging/kernel-logger/kp_kernel_logger.cpp:153:42: error: expected primary-expression before '>' token
  153 |   if (kID != std::numeric_limits<uint64_t>::max()) {
      |                                          ^
/path/to/kokkos-tools/debugging/kernel-logger/kp_kernel_logger.cpp:153:45: error: '::max' has not been declared; did you mean 'std::max'?
  153 |   if (kID != std::numeric_limits<uint64_t>::max()) {
      |                                             ^~~
      |                                             std::max
In file included from /autofs/nccs-svm1_sw/summit/gcc/10.2.0-2/include/c++/10.2.0/vector:60,
                 from /path/to/kokkos-tools/debugging/kernel-logger/kp_kernel_logger.cpp:19:
/autofs/nccs-svm1_sw/summit/gcc/10.2.0-2/include/c++/10.2.0/bits/stl_algobase.h:300:5: note: 'std::max' declared here
  300 |     max(const _Tp& __a, const _Tp& __b, _Compare __comp)
      |     ^~~
make: *** [Makefile:10: kp_kernel_logger.so] Error 1
```