### PR TITLE
Fix simple-kernel-timer Makefile

### DIFF
--- a/profiling/simple-kernel-timer/Makefile
+++ b/profiling/simple-kernel-timer/Makefile
@@ -9,13 +9,13 @@ MAKEFILE_PATH := $(subst Makefile,,$(abspath $(lastword $(MAKEFILE_LIST))))
 CXXFLAGS+=-I${MAKEFILE_PATH} -I${MAKEFILE_PATH}/../../common/makefile-only -I${MAKEFILE_PATH}../all
 
 kp_reader: ${MAKEFILE_PATH}kp_reader.cpp kp_kernel_timer.so
-	$(CXX) $(CXXFLAGS) -o kp_reader ${MAKEFILE_PATH}kp_reader.cpp
+	$(CXX) $(CXXFLAGS) -o kp_reader ${MAKEFILE_PATH}kp_reader.cpp ${MAKEFILE_PATH}kp_shared.cpp 
 
 kp_json_writer: ${MAKEFILE_PATH}kp_json_writer.cpp kp_kernel_timer.so
-	$(CXX) $(CXXFLAGS) -o kp_json_writer ${MAKEFILE_PATH}kp_json_writer.cpp
+	$(CXX) $(CXXFLAGS) -o kp_json_writer ${MAKEFILE_PATH}kp_json_writer.cpp ${MAKEFILE_PATH}kp_shared.cpp
 
 kp_kernel_timer.so: ${MAKEFILE_PATH}kp_kernel_timer.cpp ${MAKEFILE_PATH}kp_kernel_info.h
-	$(CXX) $(SHARED_CXXFLAGS) $(CXXFLAGS) -o $@ ${MAKEFILE_PATH}kp_kernel_timer.cpp
+	$(CXX) $(SHARED_CXXFLAGS) $(CXXFLAGS) -o $@ ${MAKEFILE_PATH}kp_kernel_timer.cpp ${MAKEFILE_PATH}kp_shared.cpp
 
 clean:
-	rm *.so kp_reader
+	rm *.so kp_reader kp_json_writer


### PR DESCRIPTION
#159 introduced a `kp_shared.cpp` but we forgot to update the Makefile