### PR TITLE
Fixing Readme with links to wiki descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-
-
 # Kokkos Tools
 
-Kokkos Tools provide a light-weight set of profiling and debugging utilities, which interface with instrumentation hooks built directly into the Kokkos runtime. Compared to 3rd party tools these tools can provide much cleaner, context-specific information: in particular, they allow kernel-centric analysis and they use labels provided to Kokkos constructs (kernel launches and views).
+Kokkos Tools provide a set of light-weight of profiling and debugging utilities, which interface with instrumentation hooks built directly into the Kokkos runtime. Compared to 3rd party tools these tools can provide much cleaner, context-specific information: in particular, they allow kernel-centric analysis and they use labels provided to Kokkos constructs (kernel launches and views).
 
 Under most circumstances, the profiling hooks are compiled into Kokkos executables by default assuming that the profiling hooks' version is compatible with the tools' version. No recompilation or changes to your build procedures are required.
 
@@ -10,9 +8,9 @@ Note: `Kokkos` must be configured with `Kokkos_ENABLE_LIBDL=ON` to load profilin
 
 ## General Usage
 
- To use one of the tools you have to compile it, which will generate a dynamic library. Before executing the Kokkos application you then have to set the environment variable `KOKKOS_TOOLS_LIB` to point to the dynamic library e.g. in Bash:
+ To use one of the tools you have to compile it, which will generate a dynamic library. Before executing the Kokkos application you then have to set the environment variable `KOKKOS_TOOLS_LIBS` to point to the dynamic library e.g. in the `bash` shell:
 ```
-export KOKKOS_TOOLS_LIB=${HOME}/kokkos-tools/src/tools/memory-events/kp_memory_event.so
+export KOKKOS_TOOLS_LIBS=${HOME}/kokkos-tools/src/tools/memory-events/kp_memory_event.so
 ```
 
 Many of the tools will produce an output file that uses the hostname as well as the process id as part of the filename. 
@@ -32,44 +30,46 @@ void foo() {
 
 ## Tools
 
+The following provides an overview of the tools available in the set of Kokkos Tools. Click on each Kokkos Tools name to see more details about the tool via the Kokkos Tools Wiki. 
+
 ### Utilities
 
-+ **[[KernelFilter|KernelFilter]]:**
++ [**KernelFilter:**](https://github.com/kokkos/kokkos-tools/wiki/KernelFilter) 
 
-   A tool that is used in conjunction with analysis tools, to restrict them to a subset of the application.
+    A tool which is used in conjunction with analysis tools, to restrict them to a subset of the application.
 
 ### Memory Analysis
-+ **[[MemoryHighWater|MemoryHighWater]]:**
++ [**MemoryHighWater:**](https://github.com/kokkos/kokkos-tools/wiki/MemoryHighWater)
 
-    Outputs high water mark of memory usage of the application.
+    This tool outputs the _high water mark_ of memory usage of the application. The _high water mark_ of memory usage is the highest amount of memory that is being utilized during the application's execution. 
 
-+ **[[MemoryUsage|MemoryUsage]]:**
++ [**MemoryUsage:**](https://github.com/kokkos/kokkos-tools/wiki/MemoryUsage)
 
     Generates a per Memory Space timeline of memory utilization. 
 
-+ **[[MemoryEvents|MemoryEvents]]:** 
++ [**MemoryEvents:**](https://github.com/kokkos/kokkos-tools/wiki/MemoryEvents)
 
     Tool to track memory events such as allocation and deallocation. It also provides the information of the MemoryUsage tool.
 
 ### Kernel Inspection
-+ **[[SimpleKernelTimer|SimpleKernelTimer]]:**
++ [**SimpleKernelTimer**](https://github.com/kokkos/kokkos-tools/wiki/SimpleKernelTimer)
 
     Captures basic timing information for Kernels.
 
-+ **[[KernelLogger|KernelLogger]]:**
++ [**KernelLogger**](https://github.com/kokkos/kokkos-tools/wiki/KernelLogger)
 
-    Prints kernel and region events during runtime.
+    Prints Kokkos Kernel and Region events during runtime.
 
 ### 3rd Party Profiling Tool Hooks
-+ **[[VTuneConnector|VTuneConnector]]:**
++ [**VTuneConnector:**](https://github.com/kokkos/kokkos-tools/wiki/VTuneConnector)
     
-    Provides Kernel Names to VTune, so that analysis can be performed on a per kernel base.
+    Provides Kokkos Kernel Names to VTune, so that analysis can be performed on a per kernel base.
 
-+ **[[VTuneFocusedConnector|VTuneFocusedConnector]]**
++ [**VTuneFocusedConnector:**](https://github.com/kokkos/kokkos-tools/wiki/VTuneFocusedConnector)
     
     Like VTuneConnector but turns profiling off outside of kernels. Should be used in conjunction with the KernelFilter tool. 
 
-+ **[[Timemory|Timemory]]:**
++ [**Timemory:**](https://github.com/kokkos/kokkos-tools/wiki/Timemory)
 
     Modular connector for accumulating timing, memory usage, hardware counters, and other various metrics.
     Supports controlling VTune, CUDA profilers, and TAU + kernel name forwarding to VTune, NVTX, TAU,
@@ -80,11 +80,23 @@ void foo() {
     Defining a timemory component will enable your plug-in to output to stdout, text, and JSON, 
     accumulate statistics, and utilize various portable function calls for common needs w.r.t. timers,
     resource usage, etc. 
-
+    
 
 # Building Kokkos Tools
 
-Use either CMake or provided Makefile within each subdirectory of Kokkos Tools.
+Use either CMake or Makefile to build Kokkos Tools. 
+
+## Using cmake
+
+1. create a build directory in Kokkos Tools, e.g., type `mkdir myBuild; cd myBuild` 
+2. To configure the Type `ccmake ..`  for any options you would like to enable/disable. 
+3. To compile, type `make`
+4. To install, type `make install` 
+
+## Using make
+
+To build with make, simply type `make` within each subdirectory of Kokkos Tools. 
+
 
 Building with Makefiles is currently recommended. 
 
@@ -92,12 +104,11 @@ Building with Makefiles is currently recommended.
 
 Given your tool shared library <name_of_tool_shared_library>.so (which contains kokkos profiling callback functions) and an application executable called yourApplication.exe, type: 
 
-`export KOKKOS_TOOLS_LIB=${YOUR_KOKKOS_TOOLS_DIR}/<name_of_tool_shared_lib>; ./yourApplication.exe 
+`export KOKKOS_TOOLS_LIBS=${YOUR_KOKKOS_TOOLS_DIR}/<name_of_tool_shared_lib>; ./yourApplication.exe`  
 
-# Documentation
+# Tutorial
 
-Further information and tutorials can be found here: https://github.com/kokkos/kokkos-tutorials/blob/main/LectureSeries/KokkosTutorial_07_Tools.pdf
-
+A tutorial on Kokkos Tools can be found here: https://github.com/kokkos/kokkos-tutorials/blob/main/LectureSeries/KokkosTutorial_07_Tools.pdf
 
 # Contact 
 
@@ -106,4 +117,4 @@ Further information and tutorials can be found here: https://github.com/kokkos/k
 
 # Acknowledgement
 
-Special thanks to David Poliakoff on earlier work on tools development.
+Special thanks to David Poliakoff on earlier work on Kokkos Tools development.


### PR DESCRIPTION
Fixing Readme with links to wiki descriptions by using correct markup. 
I have noted that each link in the README.md goes to the wiki. On github web browser, this may not be obvious to users. 


Has a few other minor and related formatting changes, e.g., made an enumerated list of steps for the Kokkos Tools build instructions instead of prose.

