### PR TITLE
Restore Makefile for memory-usage

### DIFF
--- a/profiling/memory-usage/Makefile
+++ b/profiling/memory-usage/Makefile
@@ -1,1 +1,15 @@
+CXX=g++
+CXXFLAGS=-O3 -std=c++11 -g
+SHARED_CXXFLAGS=-shared -fPIC
 
+all: kp_memory_usage.so
+
+MAKEFILE_PATH := $(subst Makefile,,$(abspath $(lastword $(MAKEFILE_LIST))))
+
+CXXFLAGS+=-I${MAKEFILE_PATH} -I${MAKEFILE_PATH}/../../common/makefile-only -I${MAKEFILE_PATH}../memory-events -I${MAKEFILE_PATH}../all
+
+kp_memory_usage.so: ${MAKEFILE_PATH}kp_memory_usage.cpp ${MAKEFILE_PATH}/../memory-events/kp_timer.hpp
+	$(CXX) $(SHARED_CXXFLAGS) $(CXXFLAGS) -o $@ ${MAKEFILE_PATH}kp_memory_usage.cpp
+
+clean:
+	rm *.so

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -63,8 +63,8 @@ void kokkosp_finalize_library() {
 
   for (int s = 0; s < num_spaces; s++) {
     char* fileOutput = (char*)malloc(sizeof(char) * 256);
-    sprintf(fileOutput, "%s-%d-%s.memspace_usage", hostname, pid,
-            space_name[s]);
+    snprintf(fileOutput, 256, "%s-%d-%s.memspace_usage", hostname, pid,
+             space_name[s]);
 
     FILE* ofile = fopen(fileOutput, "wb");
     free(fileOutput);


### PR DESCRIPTION
For some reason #159 deleted it. As a drive-by change, replace `sprintf` for this tool.