### PR TITLE
ci: ensure it builds on a very simple configuration

### DIFF
--- a/.github/workflows/simple-build.yml
+++ b/.github/workflows/simple-build.yml
@@ -1,0 +1,15 @@
+name: Simple build without Kokkos
+on: [push, pull_request]
+jobs:
+  simple-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Configure using CMake and compile.
+      run : |
+        # The Kokkos Tools systemtap connector requires 'dtrace'
+        sudo apt update
+        sudo apt --yes --no-install-recommends install systemtap-sdt-dev
+        cmake -B build
+        cmake --build build
+        cmake --install build --prefix ${PWD}/install


### PR DESCRIPTION
It seems there not yet a CI that builds the tools in the simplest configuration possible (i.e. without `Kokkos`).

As can be seen from the changes, `kp_sampler_skip.cpp` was not compiling. This PR introduces a CI that could detect such problems.

I could be extended in the future to `cuda` images, images with a prebuilt `Kokkos`, and so on.