### PR TITLE
Skip systemtap-connector if dtrace wasn't found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,12 @@ if(KokkosTools_ENABLE_PAPI)
 endif()
 
 if(NOT WIN32 AND NOT APPLE)
-  add_subdirectory(profiling/systemtap-connector)
+  find_program(KOKKOSTOOLS_DTRACE_EXECUTABLE dtrace)
+  if(KOKKOSTOOLS_DTRACE_EXECUTABLE)
+    add_subdirectory(profiling/systemtap-connector)
+  else()
+    message(STATUS "Skipping systemtap-connector (dtrace executable wasn't found)")
+  endif()
 endif()
 
 if(KOKKOSTOOLS_HAS_VARIORUM)


### PR DESCRIPTION
Most systems I have access to don't have `dtrace` in the `PATH` by default which makes building `KokkosTools` via `CMake` fail. This pull request just builds `systemtap-connector` if `dtrace` was found. 