### PR TITLE
Update kp_sampler_skip.cpp

### DIFF
--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -3,7 +3,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <dlfcn.h>
-#include <kokkos_core.hpp>
+#include <kp_core.hpp>
 
 namespace KokkosTools {
 namespace Sampler {

--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <dlfcn.h>
+#include <kokkos_core.hpp>
 
 namespace KokkosTools {
 namespace Sampler {


### PR DESCRIPTION
Added Kp core header file   needed for interface with Kokkos (as Expose Tool settings not found). This is aimed to fix problem with building of PR #169.

