### PR TITLE
Cleanup finding Kokkos in examples

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,8 +1,5 @@
 # Find Kokkos
-find_package(Kokkos QUIET)
-if(NOT Kokkos_FOUND)
-  message(FATAL_ERROR "Kokkos not found, set Kokkos_ROOT properly (current Kokkos_ROOT=${Kokkos_ROOT})")
-endif()
+find_package(Kokkos REQUIRED)
 foreach(_i "1;2;3") # cut .../lib/cmake/Kokkos suffix
 cmake_path(GET Kokkos_DIR PARENT_PATH Kokkos_DIR)
 endforeach()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,8 +1,5 @@
 # Find Kokkos
 find_package(Kokkos REQUIRED)
-foreach(_i "1;2;3") # cut .../lib/cmake/Kokkos suffix
-cmake_path(GET Kokkos_DIR PARENT_PATH Kokkos_DIR)
-endforeach()
 message(STATUS "Found installed Kokkos at ${Kokkos_DIR}")
 
 # Create target executable


### PR DESCRIPTION
CMake has native support for requiring a package to be found, there is no point on doing it ourselves.
Also I don't see why editing Kokkos_DIR is a good idea.  There is nothing wrong with pointing to the directory that contains the exported configuration and no obvious benefit to approximate the prefix where Kokkos was installed.  I suggest to drop the logic.
This was brought to may attention in https://github.com/kokkos/kokkos-tools/pull/188#discussion_r1182448051