### PR TITLE
Make sure kernel logger is also being installed

### DIFF
--- a/debugging/kernel-logger/CMakeLists.txt
+++ b/debugging/kernel-logger/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_library(kp_kernel_logger ${KOKKOSTOOLS_LIBRARY_MODE} kp_kernel_logger.cpp)
+kp_add_library(kp_kernel_logger kp_kernel_logger.cpp)


### PR DESCRIPTION
Library was built but not copied over to the install directory.