### PR TITLE
KOKKOS_TOOLS_LIBS and kp_add_example for Kernel Filter

### DIFF
--- a/common/kernel-filter/CMakeLists.txt
+++ b/common/kernel-filter/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_library(kp_kernel_filter ${KOKKOSTOOLS_LIBRARY_MODE} kp_kernel_filter.cpp)
+kp_add_library(kp_kernel_filter ${KOKKOSTOOLS_LIBRARY_MODE} kp_kernel_filter.cpp)

--- a/common/kernel-filter/Makefile
+++ b/common/kernel-filter/Makefile
@@ -6,6 +6,8 @@ all: kp_kernel_filter.so
 
 MAKEFILE_PATH := $(subst Makefile,,$(abspath $(lastword $(MAKEFILE_LIST))))
 
+CXXFLAGS+=-I${MAKEFILE_PATH} -I../../profiling/all/ -I../makefile-only/
+
 kp_kernel_filter.so: ${MAKEFILE_PATH}kp_kernel_filter.cpp
 	$(CXX) $(SHARED_CXXFLAGS) $(CXXFLAGS) -o $@ ${MAKEFILE_PATH}kp_kernel_filter.cpp
 

--- a/common/kernel-filter/kp_kernel_filter.cpp
+++ b/common/kernel-filter/kp_kernel_filter.cpp
@@ -129,14 +129,16 @@ extern "C" void kokkosp_init_library(const int loadSeq,
       char* profileLibrary = getenv("KOKKOS_TOOLS_LIBS");
       if (NULL == profileLibrary) {  // check for backward compatibility with
                                      // old environment variable
-        printf(
-            "Checking KOKKOS_PROFILE_LIBRARY. WARNING: This is a deprecated "
-            "variable. Please use KOKKOS_TOOLS_LIBS.\n");
+        printf("KokkosP: KOKKOS_TOOLS_LIBS not set.\n");
         profileLibrary = getenv("KOKKOS_PROFILE_LIBRARY");
         if (NULL == profileLibrary) {
           printf("KokkosP: No library to call in %s\n", profileLibrary);
           exit(-1);
         }
+        else {
+         printf("KokkosP: Found that KOKKOS_PROFILE_LIBRARY is set and it will be used.\n");
+         printf("KokkosP: Note that KOKKOS_PROFILE_LIBRARY is a deprecated variable. " 
+         "Please use KOKKOS_TOOLS_LIBS in the future.\n");
       }  // end check for backward compatability
 
       char* envBuffer =

--- a/common/kernel-filter/kp_kernel_filter.cpp
+++ b/common/kernel-filter/kp_kernel_filter.cpp
@@ -126,7 +126,18 @@ extern "C" void kokkosp_init_library(const int loadSeq,
            (filterKernels ? "enabled" : "disabled"));
 
     if (filterKernels) {
-      char* profileLibrary = getenv("KOKKOS_PROFILE_LIBRARY");
+      char* profileLibrary = getenv("KOKKOS_TOOLS_LIBS");
+      if (NULL == profileLibrary) { // check for backward compatibility with old environment variable
+        printf(
+            "Checking KOKKOS_PROFILE_LIBRARY. WARNING: This is a deprecated "
+            "variable. Please use KOKKOS_TOOLS_LIBS.\n");
+        profileLibrary = getenv("KOKKOS_PROFILE_LIBRARY");
+        if (NULL == profileLibrary) {
+          printf("KokkosP: No library to call in %s\n", profileLibrary);
+          exit(-1);
+        }
+      } // end check for backward compatability
+
       char* envBuffer =
           (char*)malloc(sizeof(char) * (strlen(profileLibrary) + 1));
       strcpy(envBuffer, profileLibrary);
@@ -182,7 +193,7 @@ extern "C" void kokkosp_init_library(const int loadSeq,
 
     printf("============================================================\n");
   }
-}
+} // end kokkosp_init_library
 
 extern "C" void kokkosp_finalize_library() {
   if (NULL != finalizeProfileLibrary) {

--- a/common/kernel-filter/kp_kernel_filter.cpp
+++ b/common/kernel-filter/kp_kernel_filter.cpp
@@ -127,7 +127,8 @@ extern "C" void kokkosp_init_library(const int loadSeq,
 
     if (filterKernels) {
       char* profileLibrary = getenv("KOKKOS_TOOLS_LIBS");
-      if (NULL == profileLibrary) { // check for backward compatibility with old environment variable
+      if (NULL == profileLibrary) {  // check for backward compatibility with
+                                     // old environment variable
         printf(
             "Checking KOKKOS_PROFILE_LIBRARY. WARNING: This is a deprecated "
             "variable. Please use KOKKOS_TOOLS_LIBS.\n");
@@ -136,7 +137,7 @@ extern "C" void kokkosp_init_library(const int loadSeq,
           printf("KokkosP: No library to call in %s\n", profileLibrary);
           exit(-1);
         }
-      } // end check for backward compatability
+      }  // end check for backward compatability
 
       char* envBuffer =
           (char*)malloc(sizeof(char) * (strlen(profileLibrary) + 1));
@@ -193,7 +194,7 @@ extern "C" void kokkosp_init_library(const int loadSeq,
 
     printf("============================================================\n");
   }
-} // end kokkosp_init_library
+}  // end kokkosp_init_library
 
 extern "C" void kokkosp_finalize_library() {
   if (NULL != finalizeProfileLibrary) {

--- a/common/kernel-filter/kp_kernel_filter.cpp
+++ b/common/kernel-filter/kp_kernel_filter.cpp
@@ -139,7 +139,8 @@ extern "C" void kokkosp_init_library(const int loadSeq,
          printf("KokkosP: Found that KOKKOS_PROFILE_LIBRARY is set and it will be used.\n");
          printf("KokkosP: Note that KOKKOS_PROFILE_LIBRARY is a deprecated variable. " 
          "Please use KOKKOS_TOOLS_LIBS in the future.\n");
-      }  // end check for backward compatability
+	  } // end note for KOKKOS_PROFILE_LIBRARY
+        }  // end check for backward compatability
 
       char* envBuffer =
           (char*)malloc(sizeof(char) * (strlen(profileLibrary) + 1));

--- a/common/kernel-filter/kp_kernel_filter.cpp
+++ b/common/kernel-filter/kp_kernel_filter.cpp
@@ -134,13 +134,16 @@ extern "C" void kokkosp_init_library(const int loadSeq,
         if (NULL == profileLibrary) {
           printf("KokkosP: No library to call in %s\n", profileLibrary);
           exit(-1);
-        }
-        else {
-         printf("KokkosP: Found that KOKKOS_PROFILE_LIBRARY is set and it will be used.\n");
-         printf("KokkosP: Note that KOKKOS_PROFILE_LIBRARY is a deprecated variable. " 
-         "Please use KOKKOS_TOOLS_LIBS in the future.\n");
-	  } // end note for KOKKOS_PROFILE_LIBRARY
-        }  // end check for backward compatability
+        } else {
+          printf(
+              "KokkosP: Found that KOKKOS_PROFILE_LIBRARY is set and it will "
+              "be used.\n");
+          printf(
+              "KokkosP: Note that KOKKOS_PROFILE_LIBRARY is a deprecated "
+              "variable. "
+              "Please use KOKKOS_TOOLS_LIBS in the future.\n");
+        }  // end note for KOKKOS_PROFILE_LIBRARY
+      }    // end check for backward compatability
 
       char* envBuffer =
           (char*)malloc(sizeof(char) * (strlen(profileLibrary) + 1));


### PR DESCRIPTION
Kernel filter is used for nvtx_focused_connector and other tools. It is outdated given changes in user interface and cmake build systems. 
This PR is associated with #176 . 

This PR does the following: 

* Read the environment KOKKOS_TOOLS_LIBS in addition to KOKKOS_PROFILE_LIBRARY. 
* Use kp_add_example for Kernel Filter