### PR TITLE
ci: adding rocm 5.7 support

### DIFF
--- a/.github/workflows/build-with-kokkos.yml
+++ b/.github/workflows/build-with-kokkos.yml
@@ -16,6 +16,8 @@ jobs:
             preset: Cuda
           - image: rocm/dev-ubuntu-22.04:5.4
             preset: ROCm
+          - image: rocm/dev-ubuntu-22.04:5.7
+            preset: ROCm
     container:
       image: ${{ matrix.image }}
     env:


### PR DESCRIPTION
This PR adds `rocm-5.7` to the pipeline.

Note that at the beginning, I tried with `rocm-5.6`, but got weird issues.