### PR TITLE
Fix matching begin with end callbacks on sampler

### DIFF
--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -156,7 +156,7 @@ void kokkosp_finalize_library() {
 
 void kokkosp_begin_parallel_for(const char* name, const uint32_t devID,
                                 uint64_t* kID) {
-  *kID = uniqID++;
+  *kID                          = uniqID++;
   static uint64_t invocationNum = 0;
   ++invocationNum;
   if ((invocationNum % kernelSampleSkip) == 0) {
@@ -172,27 +172,25 @@ void kokkosp_begin_parallel_for(const char* name, const uint32_t devID,
   }
 }
 
-void kokkosp_end_parallel_for(const uint64_t kID) { 
-
-    if (NULL != endForCallee) {
-     if ( !(infokIDSample.find(kID) == infokIDSample.end()) )
-      {
-       uint64_t retrievedNestedkID = infokIDSample[kID];
-       if (tool_verbosity > 0) { 
-       printf("KokkosP: sample %llu calling child-end function...\n",
-             (unsigned long long)(kID));
-        }
-       (*endForCallee)(retrievedNestedkID);
-       }
-     }
+void kokkosp_end_parallel_for(const uint64_t kID) {
+  if (NULL != endForCallee) {
+    if (!(infokIDSample.find(kID) == infokIDSample.end())) {
+      uint64_t retrievedNestedkID = infokIDSample[kID];
+      if (tool_verbosity > 0) {
+        printf("KokkosP: sample %llu calling child-end function...\n",
+               (unsigned long long)(kID));
+      }
+      (*endForCallee)(retrievedNestedkID);
+    }
+  }
 }
 
 void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID,
                                  uint64_t* kID) {
- *kID = uniqID++;
- static uint64_t invocationNum = 0;
- ++invocationNum;
- if ((invocationNum % kernelSampleSkip) == 0) {
+  *kID                          = uniqID++;
+  static uint64_t invocationNum = 0;
+  ++invocationNum;
+  if ((invocationNum % kernelSampleSkip) == 0) {
     if (tool_verbosity > 0) {
       printf("KokkosP: sample %llu calling child-begin function...\n",
              (unsigned long long)(*kID));
@@ -206,23 +204,21 @@ void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID,
 }
 
 void kokkosp_end_parallel_scan(const uint64_t kID) {
-
-   if (NULL != endScanCallee) {
-     if ( !(infokIDSample.find(kID) == infokIDSample.end()) )
-      {
-       uint64_t retrievedNestedkID = infokIDSample[kID];
-       if (tool_verbosity > 0) { 
-       printf("KokkosP: sample %llu calling child-end function...\n",
-             (unsigned long long)(kID));
-        }
-       (*endScanCallee)(retrievedNestedkID);
-       }
-     }
+  if (NULL != endScanCallee) {
+    if (!(infokIDSample.find(kID) == infokIDSample.end())) {
+      uint64_t retrievedNestedkID = infokIDSample[kID];
+      if (tool_verbosity > 0) {
+        printf("KokkosP: sample %llu calling child-end function...\n",
+               (unsigned long long)(kID));
+      }
+      (*endScanCallee)(retrievedNestedkID);
+    }
   }
+}
 
 void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID,
                                    uint64_t* kID) {
-  *kID = uniqID++;
+  *kID                          = uniqID++;
   static uint64_t invocationNum = 0;
   ++invocationNum;
   if ((invocationNum % kernelSampleSkip) == 0) {
@@ -240,17 +236,16 @@ void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID,
 }
 
 void kokkosp_end_parallel_reduce(const uint64_t kID) {
-   if (NULL != endScanCallee) {
-     if ( !(infokIDSample.find(kID) == infokIDSample.end()) )
-      {
-       uint64_t retrievedNestedkID = infokIDSample[kID];
-       if (tool_verbosity > 0) { 
-       printf("KokkosP: sample %llu calling child-end function...\n",
-             (unsigned long long)(kID));
-        }
-       (*endScanCallee)(retrievedNestedkID);
-       }
-     }
+  if (NULL != endScanCallee) {
+    if (!(infokIDSample.find(kID) == infokIDSample.end())) {
+      uint64_t retrievedNestedkID = infokIDSample[kID];
+      if (tool_verbosity > 0) {
+        printf("KokkosP: sample %llu calling child-end function...\n",
+               (unsigned long long)(kID));
+      }
+      (*endScanCallee)(retrievedNestedkID);
+    }
+  }
 }
 
 }  // namespace Sampler

--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -157,7 +157,9 @@ void kokkosp_finalize_library() {
 void kokkosp_begin_parallel_for(const char* name, const uint32_t devID,
                                 uint64_t* kID) {
   *kID = uniqID++;
-  if (((*kID) % kernelSampleSkip) == 0) {
+  static uint64_t invocationNum = 0;
+  ++invocationNum;
+  if ((invocationNum % kernelSampleSkip) == 0) {
     if (tool_verbosity > 0) {
       printf("KokkosP: sample %llu calling child-begin function...\n",
              (unsigned long long)(*kID));
@@ -171,7 +173,6 @@ void kokkosp_begin_parallel_for(const char* name, const uint32_t devID,
 }
 
 void kokkosp_end_parallel_for(const uint64_t kID) {
-  if ((kID % kernelSampleSkip) == 0) {
     if (tool_verbosity > 0) {
       printf("KokkosP: sample %llu calling child-end function...\n",
              (unsigned long long)(kID));
@@ -180,13 +181,14 @@ void kokkosp_end_parallel_for(const uint64_t kID) {
       uint64_t retrievedNestedkID = infokIDSample.at(kID);
       (*endForCallee)(retrievedNestedkID);
     }
-  }
 }
 
 void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID,
                                  uint64_t* kID) {
-  *kID = uniqID++;
-  if (((*kID) % kernelSampleSkip) == 0) {
+ *kID = uniqID++;
+ static uint64_t invocationNum = 0;
+ ++invocationNum;
+ if ((invocationNum % kernelSampleSkip) == 0) {
     if (tool_verbosity > 0) {
       printf("KokkosP: sample %llu calling child-begin function...\n",
              (unsigned long long)(*kID));
@@ -200,7 +202,6 @@ void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID,
 }
 
 void kokkosp_end_parallel_scan(const uint64_t kID) {
-  if ((kID % kernelSampleSkip) == 0) {
     if (tool_verbosity > 0) {
       printf("KokkosP: sample %llu calling child-end function...\n",
              (unsigned long long)(kID));
@@ -211,12 +212,13 @@ void kokkosp_end_parallel_scan(const uint64_t kID) {
       (*endScanCallee)(retrievedNestedkID);
     }
   }
-}
 
 void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID,
                                    uint64_t* kID) {
   *kID = uniqID++;
-  if (((*kID) % kernelSampleSkip) == 0) {
+  static uint64_t invocationNum = 0;
+  ++invocationNum;
+  if ((invocationNum % kernelSampleSkip) == 0) {
     if (tool_verbosity > 0) {
       printf("KokkosP: sample %llu calling child-begin function...\n",
              (unsigned long long)(*kID));
@@ -231,17 +233,14 @@ void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID,
 }
 
 void kokkosp_end_parallel_reduce(const uint64_t kID) {
-  if ((kID % kernelSampleSkip) == 0) {
     if (tool_verbosity > 0) {
       printf("KokkosP: sample %llu calling child-end function...\n",
              (unsigned long long)(kID));
     }
-
     if (NULL != endReduceCallee) {
       uint64_t retrievedNestedkID = infokIDSample.at(kID);
       (*endReduceCallee)(retrievedNestedkID);
     }
-  }
 }
 
 }  // namespace Sampler

--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -172,15 +172,19 @@ void kokkosp_begin_parallel_for(const char* name, const uint32_t devID,
   }
 }
 
-void kokkosp_end_parallel_for(const uint64_t kID) {
-    if (tool_verbosity > 0) {
-      printf("KokkosP: sample %llu calling child-end function...\n",
-             (unsigned long long)(kID));
-    }
+void kokkosp_end_parallel_for(const uint64_t kID) { 
+
     if (NULL != endForCallee) {
-      uint64_t retrievedNestedkID = infokIDSample.at(kID);
-      (*endForCallee)(retrievedNestedkID);
-    }
+     if ( !(infokIDSample.find(kID) == infokIDSample.end()) )
+      {
+       uint64_t retrievedNestedkID = infokIDSample.at(kID);
+       if (tool_verbosity > 0) { 
+       printf("KokkosP: sample %llu calling child-end function...\n",
+             (unsigned long long)(kID));
+        }
+       (*endForCallee)(retrievedNestedkID);
+       }
+     }
 }
 
 void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID,

--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -177,7 +177,7 @@ void kokkosp_end_parallel_for(const uint64_t kID) {
     if (NULL != endForCallee) {
      if ( !(infokIDSample.find(kID) == infokIDSample.end()) )
       {
-       uint64_t retrievedNestedkID = infokIDSample.at(kID);
+       uint64_t retrievedNestedkID = infokIDSample[kID];
        if (tool_verbosity > 0) { 
        printf("KokkosP: sample %llu calling child-end function...\n",
              (unsigned long long)(kID));
@@ -206,15 +206,18 @@ void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID,
 }
 
 void kokkosp_end_parallel_scan(const uint64_t kID) {
-    if (tool_verbosity > 0) {
-      printf("KokkosP: sample %llu calling child-end function...\n",
-             (unsigned long long)(kID));
-    }
 
-    if (NULL != endScanCallee) {
-      uint64_t retrievedNestedkID = infokIDSample.at(kID);
-      (*endScanCallee)(retrievedNestedkID);
-    }
+   if (NULL != endScanCallee) {
+     if ( !(infokIDSample.find(kID) == infokIDSample.end()) )
+      {
+       uint64_t retrievedNestedkID = infokIDSample[kID];
+       if (tool_verbosity > 0) { 
+       printf("KokkosP: sample %llu calling child-end function...\n",
+             (unsigned long long)(kID));
+        }
+       (*endScanCallee)(retrievedNestedkID);
+       }
+     }
   }
 
 void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID,
@@ -237,14 +240,17 @@ void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID,
 }
 
 void kokkosp_end_parallel_reduce(const uint64_t kID) {
-    if (tool_verbosity > 0) {
-      printf("KokkosP: sample %llu calling child-end function...\n",
+   if (NULL != endScanCallee) {
+     if ( !(infokIDSample.find(kID) == infokIDSample.end()) )
+      {
+       uint64_t retrievedNestedkID = infokIDSample[kID];
+       if (tool_verbosity > 0) { 
+       printf("KokkosP: sample %llu calling child-end function...\n",
              (unsigned long long)(kID));
-    }
-    if (NULL != endReduceCallee) {
-      uint64_t retrievedNestedkID = infokIDSample.at(kID);
-      (*endReduceCallee)(retrievedNestedkID);
-    }
+        }
+       (*endScanCallee)(retrievedNestedkID);
+       }
+     }
 }
 
 }  // namespace Sampler


### PR DESCRIPTION
Fix for sampler for matching. Essential for child callbacks and functionality of sampler utility with, e.g., space-time-stack. 