### PR TITLE
kp_sampler_skip.cpp: erase for efficiency of unordered map  

### DIFF
--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -244,6 +244,7 @@ void kokkosp_end_parallel_reduce(const uint64_t kID) {
                (unsigned long long)(kID));
       }
       (*endScanCallee)(retrievedNestedkID);
+      infokIDSample.erase(kID);
     }
   }
 }

--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -181,6 +181,7 @@ void kokkosp_end_parallel_for(const uint64_t kID) {
                (unsigned long long)(kID));
       }
       (*endForCallee)(retrievedNestedkID);
+      infokIDSample.erase(kID);
     }
   }
 }
@@ -212,6 +213,7 @@ void kokkosp_end_parallel_scan(const uint64_t kID) {
                (unsigned long long)(kID));
       }
       (*endScanCallee)(retrievedNestedkID);
+      infokIDSample.erase(kID);
     }
   }
 }


### PR DESCRIPTION
This PR improves efficiency in space for the sampler: In hash table infokIDSample, the entry mykID of the sample is removed each time it is used by kokkosp_end_* function with input parameter mykID. 