### PR TITLE
Fence on sample only

### DIFF
--- a/common/kokkos-sampler/Makefile
+++ b/common/kokkos-sampler/Makefile
@@ -1,4 +1,4 @@
-CXX = clang++
+CXX = g++
 
 CXXFLAGS = -O3 -std=c++17 -g
 

--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -33,7 +33,7 @@ static endFunction endReduceCallee             = NULL;
 
 void kokkosp_request_tool_settings(const uint32_t,
                                    Kokkos_Tools_ToolSettings* settings) {
-    settings->requires_global_fencing = false;
+  settings->requires_global_fencing = false;
 }
 
 // set of functions from Kokkos ToolProgrammingInterface (includes fence)

--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -279,7 +279,7 @@ void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID,
     if (NULL != beginReduceCallee) {
       uint64_t nestedkID = 0;
       if (tool_globFence) {
-        invoke_ktools_fence(devID);
+        invoke_ktools_fence(0);
       }
       (*beginReduceCallee)(name, devID, &nestedkID);
       infokIDSample.insert({*kID, nestedkID});

--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -33,11 +33,7 @@ static endFunction endReduceCallee             = NULL;
 
 void kokkosp_request_tool_settings(const uint32_t,
                                    Kokkos_Tools_ToolSettings* settings) {
-  if (0 == tool_globFence) {
     settings->requires_global_fencing = false;
-  } else {
-    settings->requires_global_fencing = true;
-  }
 }
 
 // set of functions from Kokkos ToolProgrammingInterface (includes fence)

--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -81,8 +81,9 @@ void kokkosp_provide_tool_programming_interface(
           "KokkosP: Note: Number of functions in Tools Programming Interface "
           "is 0!\n");
   }
+ 
   tpi_funcs = *funcsFromTPI;
-}
+ }
 
 
 void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
@@ -329,8 +330,8 @@ void kokkosp_end_parallel_reduce(const uint64_t kID) {
 extern "C" {
 
 namespace impl = KokkosTools::Sampler;
-
 EXPOSE_TOOL_SETTINGS(impl::kokkosp_request_tool_settings)
+EXPOSE_PROVIDE_TOOL_PROGRAMMING_INTERFACE(impl::kokkosp_provide_tool_programming_interface)
 EXPOSE_INIT(impl::kokkosp_init_library)
 EXPOSE_FINALIZE(impl::kokkosp_finalize_library)
 EXPOSE_BEGIN_PARALLEL_FOR(impl::kokkosp_begin_parallel_for)

--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -62,15 +62,17 @@ void invoke_ktools_fence(uint32_t devID) {
   if (tpi_funcs.fence != nullptr) {
     tpi_funcs.fence(devID);
     if (tool_verbosity > 1) {
-      printf("KokkosP: Sampler utility sucessfully invoked " 
-        " tool-induced fence on device %d\n", getDeviceID(devID));
+      printf(
+          "KokkosP: Sampler utility sucessfully invoked "
+          " tool-induced fence on device %d\n",
+          getDeviceID(devID));
     }
   } else {
-         printf(
+    printf(
         "KokkosP: FATAL: Kokkos Tools Programming Interface's tool-invoked "
         "Fence is NULL!\n");
-         exit(-1);
-     }  
+    exit(-1);
+  }
 }
 
 void kokkosp_provide_tool_programming_interface(
@@ -83,7 +85,6 @@ void kokkosp_provide_tool_programming_interface(
   }
   tpi_funcs = *funcsFromTPI;
 }
-
 
 void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
                           const uint32_t devInfoCount, void* deviceInfo) {
@@ -231,10 +232,10 @@ void kokkosp_end_parallel_for(const uint64_t kID) {
                (unsigned long long)(kID));
       }
       get_global_fence_choice();  // re-read environment variable to get most
-                                // accurate
+                                  // accurate
       if (tool_globFence) {
         invoke_ktools_fence(0);
-       }
+      }
       (*endForCallee)(retrievedNestedkID);
     }
   }
@@ -253,9 +254,9 @@ void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID,
     if (NULL != beginScanCallee) {
       uint64_t nestedkID = 0;
       get_global_fence_choice();  // re-read environment variable to get most
-                                // accurate
+                                  // accurate
       if (tool_globFence) {
-          invoke_ktools_fence(0);
+        invoke_ktools_fence(0);
       }
       (*beginScanCallee)(name, devID, &nestedkID);
       infokIDSample.insert({*kID, nestedkID});
@@ -271,11 +272,11 @@ void kokkosp_end_parallel_scan(const uint64_t kID) {
         printf("KokkosP: sample %llu calling child-end function...\n",
                (unsigned long long)(kID));
       }
-       get_global_fence_choice();  // re-read environment variable to get most
-                                // accurate
-       if (tool_globFence) {
-          invoke_ktools_fence(0);
-       }
+      get_global_fence_choice();  // re-read environment variable to get most
+                                  // accurate
+      if (tool_globFence) {
+        invoke_ktools_fence(0);
+      }
       (*endScanCallee)(retrievedNestedkID);
     }
   }
@@ -291,11 +292,11 @@ void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID,
       printf("KokkosP: sample %llu calling child-begin function...\n",
              (unsigned long long)(*kID));
     }
-    
+
     if (NULL != beginReduceCallee) {
       uint64_t nestedkID = 0;
       get_global_fence_choice();  // re-read environment variable to get most
-                                // accurate
+                                  // accurate
       if (tool_globFence) {
         invoke_ktools_fence(0);
       }
@@ -313,11 +314,11 @@ void kokkosp_end_parallel_reduce(const uint64_t kID) {
         printf("KokkosP: sample %llu calling child-end function...\n",
                (unsigned long long)(kID));
       }
-       get_global_fence_choice();  // re-read environment variable to get most
-                                // accurate
-       if (tool_globFence) {
-          invoke_ktools_fence(0);
-       }
+      get_global_fence_choice();  // re-read environment variable to get most
+                                  // accurate
+      if (tool_globFence) {
+        invoke_ktools_fence(0);
+      }
       (*endScanCallee)(retrievedNestedkID);
     }
   }

--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -212,7 +212,7 @@ void kokkosp_begin_parallel_for(const char* name, const uint32_t devID,
     get_global_fence_choice();  // re-read environment variable to get most
                                 // accurate
     if (tool_globFence) {
-      invoke_ktools_fence(devID);
+      invoke_ktools_fence(0);
     }
     if (NULL != beginForCallee) {
       uint64_t nestedkID = 0;
@@ -233,7 +233,7 @@ void kokkosp_end_parallel_for(const uint64_t kID) {
       get_global_fence_choice();  // re-read environment variable to get most
                                 // accurate
       if (tool_globFence) {
-        invoke_ktools_fence(devID);
+        invoke_ktools_fence(0);
        }
       (*endForCallee)(retrievedNestedkID);
     }
@@ -255,7 +255,7 @@ void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID,
       get_global_fence_choice();  // re-read environment variable to get most
                                 // accurate
       if (tool_globFence) {
-          invoke_ktools_fence(devID);
+          invoke_ktools_fence(0);
       }
       (*beginScanCallee)(name, devID, &nestedkID);
       infokIDSample.insert({*kID, nestedkID});
@@ -274,7 +274,7 @@ void kokkosp_end_parallel_scan(const uint64_t kID) {
        get_global_fence_choice();  // re-read environment variable to get most
                                 // accurate
        if (tool_globFence) {
-          invoke_ktools_fence(devID);
+          invoke_ktools_fence(0);
        }
       (*endScanCallee)(retrievedNestedkID);
     }
@@ -297,7 +297,7 @@ void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID,
       get_global_fence_choice();  // re-read environment variable to get most
                                 // accurate
       if (tool_globFence) {
-        invoke_ktools_fence(devID);
+        invoke_ktools_fence(0);
       }
       (*beginReduceCallee)(name, devID, &nestedkID);
       infokIDSample.insert({*kID, nestedkID});
@@ -316,7 +316,7 @@ void kokkosp_end_parallel_reduce(const uint64_t kID) {
        get_global_fence_choice();  // re-read environment variable to get most
                                 // accurate
        if (tool_globFence) {
-          invoke_ktools_fence(devID);
+          invoke_ktools_fence(0);
        }
       (*endScanCallee)(retrievedNestedkID);
     }

--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -40,14 +40,6 @@ void kokkosp_request_tool_settings(const uint32_t,
   }
 }
 
-void get_global_fence_choice() {
-  // re-read environment variable to get most accurate value
-  const char* tool_globFence_str = getenv("KOKKOS_TOOLS_GLOBALFENCES");
-  if (NULL != tool_globFence_str) {
-    tool_globFence = atoi(tool_globFence_str);
-  }
-}
-
 // set of functions from Kokkos ToolProgrammingInterface (includes fence)
 Kokkos::Tools::Experimental::ToolProgrammingInterface tpi_funcs;
 
@@ -83,7 +75,6 @@ void kokkosp_provide_tool_programming_interface(
           "KokkosP: Note: Number of functions in Tools Programming Interface "
           "is 0!\n");
   }
-
   tpi_funcs = *funcsFromTPI;
 }
 
@@ -211,10 +202,8 @@ void kokkosp_begin_parallel_for(const char* name, const uint32_t devID,
       printf("KokkosP: sample %llu calling child-begin function...\n",
              (unsigned long long)(*kID));
     }
-    get_global_fence_choice();  // re-read environment variable to get most
-                                // accurate
     if (tool_globFence) {
-      invoke_ktools_fence(devID);
+      invoke_ktools_fence(0);
     }
     if (NULL != beginForCallee) {
       uint64_t nestedkID = 0;
@@ -232,8 +221,6 @@ void kokkosp_end_parallel_for(const uint64_t kID) {
         printf("KokkosP: sample %llu calling child-end function...\n",
                (unsigned long long)(kID));
       }
-      get_global_fence_choice();  // re-read environment variable to get most
-                                  // accurate
       if (tool_globFence) {
         invoke_ktools_fence(0);
       }
@@ -254,8 +241,6 @@ void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID,
     }
     if (NULL != beginScanCallee) {
       uint64_t nestedkID = 0;
-      get_global_fence_choice();  // re-read environment variable to get most
-                                  // accurate
       if (tool_globFence) {
         invoke_ktools_fence(0);
       }
@@ -273,8 +258,6 @@ void kokkosp_end_parallel_scan(const uint64_t kID) {
         printf("KokkosP: sample %llu calling child-end function...\n",
                (unsigned long long)(kID));
       }
-      get_global_fence_choice();  // re-read environment variable to get most
-                                  // accurate
       if (tool_globFence) {
         invoke_ktools_fence(0);
       }
@@ -293,11 +276,8 @@ void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID,
       printf("KokkosP: sample %llu calling child-begin function...\n",
              (unsigned long long)(*kID));
     }
-
     if (NULL != beginReduceCallee) {
       uint64_t nestedkID = 0;
-      get_global_fence_choice();  // re-read environment variable to get most
-                                  // accurate
       if (tool_globFence) {
         invoke_ktools_fence(devID);
       }
@@ -315,8 +295,6 @@ void kokkosp_end_parallel_reduce(const uint64_t kID) {
         printf("KokkosP: sample %llu calling child-end function...\n",
                (unsigned long long)(kID));
       }
-      get_global_fence_choice();  // re-read environment variable to get most
-                                  // accurate
       if (tool_globFence) {
         invoke_ktools_fence(0);
       }

--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -212,7 +212,7 @@ void kokkosp_begin_parallel_for(const char* name, const uint32_t devID,
     get_global_fence_choice();  // re-read environment variable to get most
                                 // accurate
     if (tool_globFence) {
-      invoke_ktools_fence(0);
+      invoke_ktools_fence(devID);
     }
     if (NULL != beginForCallee) {
       uint64_t nestedkID = 0;
@@ -255,7 +255,7 @@ void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID,
       get_global_fence_choice();  // re-read environment variable to get most
                                 // accurate
       if (tool_globFence) {
-          invoke_ktools_fence(0);
+          invoke_ktools_fence(devID);
       }
       (*beginScanCallee)(name, devID, &nestedkID);
       infokIDSample.insert({*kID, nestedkID});
@@ -297,7 +297,7 @@ void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID,
       get_global_fence_choice();  // re-read environment variable to get most
                                 // accurate
       if (tool_globFence) {
-        invoke_ktools_fence(0);
+        invoke_ktools_fence(devID);
       }
       (*beginReduceCallee)(name, devID, &nestedkID);
       infokIDSample.insert({*kID, nestedkID});

--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -83,9 +83,9 @@ void kokkosp_provide_tool_programming_interface(
           "KokkosP: Note: Number of functions in Tools Programming Interface "
           "is 0!\n");
   }
- 
+
   tpi_funcs = *funcsFromTPI;
- }
+}
 
 void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
                           const uint32_t devInfoCount, void* deviceInfo) {
@@ -332,7 +332,8 @@ extern "C" {
 
 namespace impl = KokkosTools::Sampler;
 EXPOSE_TOOL_SETTINGS(impl::kokkosp_request_tool_settings)
-EXPOSE_PROVIDE_TOOL_PROGRAMMING_INTERFACE(impl::kokkosp_provide_tool_programming_interface)
+EXPOSE_PROVIDE_TOOL_PROGRAMMING_INTERFACE(
+    impl::kokkosp_provide_tool_programming_interface)
 EXPOSE_INIT(impl::kokkosp_init_library)
 EXPOSE_FINALIZE(impl::kokkosp_finalize_library)
 EXPOSE_BEGIN_PARALLEL_FOR(impl::kokkosp_begin_parallel_for)

--- a/profiling/all/kp_core.hpp
+++ b/profiling/all/kp_core.hpp
@@ -48,14 +48,22 @@ using Kokkos::Tools::SpaceHandle;
 #define EXPOSE_PROFILE_EVENT(FUNC_NAME)
 #define EXPOSE_BEGIN_FENCE(FUNC_NAME)
 #define EXPOSE_END_FENCE(FUNC_NAME)
+#define EXPOSE_PROVIDE_TOOL_PROGRAMMING_INTERFACE(FUNC_NAME)
+
 
 #else
+
+#define EXPOSE_PROVIDE_TOOL_PROGRAMMING_INTERFACE(FUNC_NAME)                                  \
+  __attribute__((weak)) void kokkosp_provide_tool_programming_interface(              \
+      const uint32_t num_actions, Kokkos_Tools_ToolProgrammingInterface* ptpi) { \
+    FUNC_NAME(num_actions, ptpi);                                    \
+  }
 
 #define EXPOSE_TOOL_SETTINGS(FUNC_NAME)                                  \
   __attribute__((weak)) void kokkosp_request_tool_settings(              \
       const uint32_t num_actions, Kokkos_Tools_ToolSettings* settings) { \
     FUNC_NAME(num_actions, settings);                                    \
-  }
+  } 
 
 #define EXPOSE_INIT(FUNC_NAME)                                  \
   __attribute__((weak)) void kokkosp_init_library(              \

--- a/profiling/all/kp_core.hpp
+++ b/profiling/all/kp_core.hpp
@@ -50,20 +50,20 @@ using Kokkos::Tools::SpaceHandle;
 #define EXPOSE_END_FENCE(FUNC_NAME)
 #define EXPOSE_PROVIDE_TOOL_PROGRAMMING_INTERFACE(FUNC_NAME)
 
-
 #else
 
-#define EXPOSE_PROVIDE_TOOL_PROGRAMMING_INTERFACE(FUNC_NAME)                                  \
-  __attribute__((weak)) void kokkosp_provide_tool_programming_interface(              \
-      const uint32_t num_actions, Kokkos_Tools_ToolProgrammingInterface* ptpi) { \
-    FUNC_NAME(num_actions, ptpi);                                    \
+#define EXPOSE_PROVIDE_TOOL_PROGRAMMING_INTERFACE(FUNC_NAME)             \
+  __attribute__((weak)) void kokkosp_provide_tool_programming_interface( \
+      const uint32_t num_actions,                                        \
+      Kokkos_Tools_ToolProgrammingInterface* ptpi) {                     \
+    FUNC_NAME(num_actions, ptpi);                                        \
   }
 
 #define EXPOSE_TOOL_SETTINGS(FUNC_NAME)                                  \
   __attribute__((weak)) void kokkosp_request_tool_settings(              \
       const uint32_t num_actions, Kokkos_Tools_ToolSettings* settings) { \
     FUNC_NAME(num_actions, settings);                                    \
-  } 
+  }
 
 #define EXPOSE_INIT(FUNC_NAME)                                  \
   __attribute__((weak)) void kokkosp_init_library(              \


### PR DESCRIPTION
This PR fences only when a sample event is taken, i.e., at the beginning of the sample in kokkosp_begin_xyz( mykID) and at the end of the corresponding sample in kokkosp_end_xyz(mykID). This improves efficiency of Kokkos Tools, when sampling is done.  

Note that provide tools programming interface must be exposed in profiling/all/kp_core.hpp. This wasn't done previously, i.e., it is not in the develop branch of Kokkos Tools, and it is useful for other tools needing the tools programming interface. 

Notes from PR #194  are relevant to this PR. 

