### PR TITLE
cicd(gcc): add job with gcc 12 and nvcc 12.2.0

### DIFF
--- a/.github/workflows/build-with-kokkos.yml
+++ b/.github/workflows/build-with-kokkos.yml
@@ -12,31 +12,69 @@ jobs:
         include:
           - image: ubuntu:22.04
             preset: OpenMP
+            compiler: default
           - image: nvidia/cuda:12.1.0-devel-ubuntu22.04
             preset: Cuda
+            compiler: default
+          - image: nvidia/cuda:12.2.0-devel-ubuntu22.04
+            preset: Cuda
+            compiler: {cpp: g++-12, c: gcc-12}
           - image: rocm/dev-ubuntu-22.04:5.4
             preset: ROCm
+            compiler: default
           - image: rocm/dev-ubuntu-22.04:5.7
             preset: ROCm
+            compiler: default
     container:
       image: ${{ matrix.image }}
     env:
       Kokkos_ROOT: /opt/kokkos
     steps:
       - name: Checkout Kokkos Tools
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Checkout Kokkos repository at latest develop
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: kokkos/kokkos
           path: kokkos
           ref: develop
-      - name: Install CMake, compilers, OpenMPI and dtrace
-        run: |
+      - name: Install compilers
+        run : |
           apt update
+
+          if [ ${{ matrix.compiler }} != 'default' ];then
+              apt --yes --no-install-recommends install ${{ matrix.compiler.c }} ${{ matrix.compiler.cpp }}
+              export CC=${{ matrix.compiler.c }}
+              export CXX=${{ matrix.compiler.cpp }}
+          else
+              apt --yes --no-install-recommends install gcc g++
+              export CC=gcc
+              export CXX=g++
+          fi
+
+          echo "CC=$CC"   >> $GITHUB_ENV
+          echo "CXX=$CXX" >> $GITHUB_ENV
+
+          case ${{ matrix.preset }} in
+              *OpenMP* )
+                  echo "Preset is OpenMP, nothing to do."
+                  ;;
+              *Cuda* )
+                  echo "Preset is Cuda. Setting 'NVCC_WRAPPER_DEFAULT_COMPILER' to '$CXX'."
+                  echo "NVCC_WRAPPER_DEFAULT_COMPILER=$CXX" >> $GITHUB_ENV
+                  ;;
+              *ROCm* )
+                  echo "Preset is ROCm, nothing to do."
+                  ;;
+              * )
+                  echo "Unsupported preset '${{ matrix.preset }}'."
+                  exit -1
+          esac
+
+      - name: Install CMake, OpenMPI and dtrace
+        run: |
           apt --yes --no-install-recommends install \
             cmake make \
-            gcc g++ \
             libopenmpi-dev \
             systemtap-sdt-dev
       - name: Compile and install Kokkos

--- a/profiling/nvtx-connector/kp_nvtx_connector.cpp
+++ b/profiling/nvtx-connector/kp_nvtx_connector.cpp
@@ -20,6 +20,8 @@
 #include <string>
 #include <limits>
 
+#include <pthread.h>
+
 #include "nvToolsExt.h"
 
 #include "kp_core.hpp"

--- a/profiling/nvtx-focused-connector/kp_nvtx_focused_connector.cpp
+++ b/profiling/nvtx-focused-connector/kp_nvtx_focused_connector.cpp
@@ -23,6 +23,8 @@
 #include <cxxabi.h>
 #include <cuda_profiler_api.h>
 
+#include <pthread.h>
+
 #include "kp_nvtx_focused_connector_domain.h"
 
 #include "nvToolsExt.h"


### PR DESCRIPTION
## Summary

* This PR adds a job using `Cuda 12.2.0` with `gcc 12`.
* It also fixes a missing `pthread.h` include in the `nvtx` connector (only from `gcc 12` onwards).

## Details

In order to make the missing `pthread.h` problem appear, I needed to compile with `gcc 12`, which is not the default compiler in `Ubuntu 22.04` images.

Therefore, the actions strategy matrix now has a `compiler` component, that can be set to `default` or anything else.

* `default` will install `gcc` and `g++`. For instance, in `Ubuntu 22.04` images it is version 11.
* Otherwise, use an array like `{c : my_c_compiler, cpp : my_cpp_compiler}`. It will install these compilers instead.

Then just set `CC` or `CXX` to instruct `CMake` which compilers to use.

Note that for the `Cuda` preset case, we also need to set `NVCC_WRAPPER_DEFAULT_COMPILER` because it will use `Kokkos`'s `nvcc_wrapper` that by default uses `g++` for the `c++` compiler.