### PR TITLE
type: renaming `Kokkos_Tools_OptimizationGoal`

### DIFF
--- a/profiling/all/impl/Kokkos_Profiling_C_Interface.h
+++ b/profiling/all/impl/Kokkos_Profiling_C_Interface.h
@@ -152,7 +152,7 @@ enum Kokkos_Tools_OptimizationType {
   Kokkos_Tools_Maximize
 };
 
-struct Kokkos_Tools_OptimzationGoal {
+struct Kokkos_Tools_OptimizationGoal {
   size_t type_id;
   enum Kokkos_Tools_OptimizationType goal;
 };
@@ -218,7 +218,7 @@ typedef void (*Kokkos_Tools_contextBeginFunction)(const size_t);
 typedef void (*Kokkos_Tools_contextEndFunction)(
     const size_t, struct Kokkos_Tools_VariableValue);
 typedef void (*Kokkos_Tools_optimizationGoalDeclarationFunction)(
-    const size_t, const struct Kokkos_Tools_OptimzationGoal goal);
+    const size_t, const struct Kokkos_Tools_OptimizationGoal goal);
 
 struct Kokkos_Profiling_EventSet {
   Kokkos_Profiling_initFunction init;

--- a/profiling/all/impl/Kokkos_Profiling_Interface.hpp
+++ b/profiling/all/impl/Kokkos_Profiling_Interface.hpp
@@ -220,7 +220,7 @@ using ValueType           = Kokkos_Tools_VariableInfo_ValueType;
 using CandidateValueType  = Kokkos_Tools_VariableInfo_CandidateValueType;
 using SetOrRange          = Kokkos_Tools_VariableInfo_SetOrRange;
 using VariableInfo        = Kokkos_Tools_VariableInfo;
-using OptimizationGoal    = Kokkos_Tools_OptimzationGoal;
+using OptimizationGoal    = Kokkos_Tools_OptimizationGoal;
 using TuningString        = Kokkos_Tools_Tuning_String;
 using VariableValue       = Kokkos_Tools_VariableValue;
 


### PR DESCRIPTION
This PR is extracted from #218.

It is correcting a typo.

A PR is probably needed in `Kokkos` too.