### PR TITLE
papi(bug): use `kp_add_library` to ensure it is installed

### DIFF
--- a/.github/workflows/build-with-kokkos.yml
+++ b/.github/workflows/build-with-kokkos.yml
@@ -71,12 +71,13 @@ jobs:
                   exit -1
           esac
 
-      - name: Install CMake, OpenMPI and dtrace
+      - name: Install CMake, OpenMPI, PAPI and dtrace
         run: |
           apt --yes --no-install-recommends install \
             cmake make \
             libopenmpi-dev \
-            systemtap-sdt-dev
+            systemtap-sdt-dev \
+            libpapi-dev
       - name: Compile and install Kokkos
         working-directory: kokkos
         run: |

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,7 +9,8 @@
                 "CMAKE_CXX_STANDARD"                : "17",
                 "KokkosTools_ENABLE_EXAMPLES"       : "ON",
                 "KokkosTools_ENABLE_SINGLE"         : "ON",
-                "KokkosTools_ENABLE_MPI"            : "ON"
+                "KokkosTools_ENABLE_MPI"            : "ON",
+                "KokkosTools_ENABLE_PAPI"           : "ON"
             }
         },
         {

--- a/profiling/papi-connector/CMakeLists.txt
+++ b/profiling/papi-connector/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(kp_papi_connector SHARED kp_papi_connector.cpp)
+kp_add_library(kp_papi_connector kp_papi_connector.cpp)
 
 target_link_libraries(kp_papi_connector PRIVATE PAPI::PAPI)


### PR DESCRIPTION
The `PAPI` connector was not part of the installed files, because it was added with `add_library` instead of `kp_add_library`.

This PR also adds `libpapi-dev` in the `build-with-kokkos.yaml` pipeline so we can at least build the `PAPI` connector.