### PR TITLE
Add header/legend line to kp_reader

### DIFF
--- a/profiling/simple-kernel-timer/kp_reader.cpp
+++ b/profiling/simple-kernel-timer/kp_reader.cpp
@@ -103,7 +103,7 @@ int main(int argc, char* argv[]) {
   }
 
   printf(
-      "(Type)   Total Time, Call Count, Avg. Time per Call, %%Total Time in "
+      " (Type)   Total Time, Call Count, Avg. Time per Call, %%Total Time in "
       "Kernels, %%Total Program Time\n");
   printf(
       "------------------------------------------------------------------------"

--- a/profiling/simple-kernel-timer/kp_reader.cpp
+++ b/profiling/simple-kernel-timer/kp_reader.cpp
@@ -102,6 +102,9 @@ int main(int argc, char* argv[]) {
     }
   }
 
+  printf("(Type)   Total Time, Call Count, Avg. Time per Call, %%Total Time in Kernels, %%Total Program Time\n");
+  printf("-------------------------------------------------------------------------\n\n");
+
   printf("Regions: \n\n");
 
   for (unsigned int i = 0; i < kernelInfo.size(); i++) {

--- a/profiling/simple-kernel-timer/kp_reader.cpp
+++ b/profiling/simple-kernel-timer/kp_reader.cpp
@@ -102,8 +102,12 @@ int main(int argc, char* argv[]) {
     }
   }
 
-  printf("(Type)   Total Time, Call Count, Avg. Time per Call, %%Total Time in Kernels, %%Total Program Time\n");
-  printf("-------------------------------------------------------------------------\n\n");
+  printf(
+      "(Type)   Total Time, Call Count, Avg. Time per Call, %%Total Time in "
+      "Kernels, %%Total Program Time\n");
+  printf(
+      "------------------------------------------------------------------------"
+      "-\n\n");
 
   printf("Regions: \n\n");
 


### PR DESCRIPTION
Add header line to kp_reader describing what each column means.

For example:
```
[bmkelle@s1042556 unit_test]$ ~/kp_reader s1042556-55120.dat
 (Type)   Total Time, Call Count, Avg. Time per Call, %Total Time in Kernels, %Total Program Time
-------------------------------------------------------------------------

Regions: 


-------------------------------------------------------------------------
Kernels: 

- KokkosKernels::Common::SymmetrizeGraphSymbolicHashMap::S1
 (ParFor)   0.986542 14 0.070467 24.654143 12.271012
- KokkosKernels::Common::SymmetrizeGraphSymbolicHashMap::S0
 (ParFor)   0.977042 14 0.069789 24.416739 12.152850
...
```

Note, I didn't try to space this out differently with ``--fixed-width 1`` because the columns containing numbers tend to be narrower than the corresponding header entry.