### PR TITLE
space-time-stack: allow demangled names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ option(KokkosTools_ENABLE_MPI     "Enable MPI support"              OFF)
 option(KokkosTools_ENABLE_CALIPER "Enable building Caliper library" OFF)
 option(KokkosTools_ENABLE_APEX    "Enable building Apex library"    OFF)
 option(KokkosTools_ENABLE_EXAMPLES "Build examples"                 OFF)
+option(KokkosTools_ENABLE_TESTS    "Build tests"                    OFF)
+
 # Advanced settings
 option(KokkosTools_REUSE_KOKKOS_COMPILER "Set the compiler and flags based on installed Kokkos settings" OFF)
 mark_as_advanced(KokkosTools_REUSE_KOKKOS_COMPILER)
@@ -115,6 +117,9 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/profiling/all)
 
 set(COMMON_HEADERS_PATH ${CMAKE_CURRENT_BINARY_DIR}/common)
 include_directories(${COMMON_HEADERS_PATH})
+
+# Allow all tools to include any file.
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/common)
 
 set(SINGLELIB_PROFILERS "" CACHE STRING "" FORCE)
 
@@ -262,6 +267,12 @@ if(KokkosTools_ENABLE_EXAMPLES)
     enable_testing()
     add_subdirectory(example)
   endif()
+endif()
+
+# Tests
+if(KokkosTools_ENABLE_TESTS)
+  enable_testing()
+  add_subdirectory(tests)
 endif()
 
 # Install exports

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,7 +10,8 @@
                 "KokkosTools_ENABLE_EXAMPLES"       : "ON",
                 "KokkosTools_ENABLE_SINGLE"         : "ON",
                 "KokkosTools_ENABLE_MPI"            : "ON",
-                "KokkosTools_ENABLE_PAPI"           : "ON"
+                "KokkosTools_ENABLE_PAPI"           : "ON",
+                "KokkosTools_ENABLE_TESTS"          : "ON"
             }
         },
         {

--- a/common/utils/demangle.hpp
+++ b/common/utils/demangle.hpp
@@ -1,0 +1,74 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOSTOOLS_COMMON_UTILS_DEMANGLE_HPP
+#define KOKKOSTOOLS_COMMON_UTILS_DEMANGLE_HPP
+
+#include <string>
+
+#if defined(__GXX_ABI_VERSION)
+#define HAVE_GCC_ABI_DEMANGLE
+#endif
+
+#if defined(HAVE_GCC_ABI_DEMANGLE)
+#include <cxxabi.h>
+#endif  // HAVE_GCC_ABI_DEMANGLE
+
+namespace KokkosTools {
+
+//! Demangle @p mangled_name.
+inline std::string demangleName(const std::string_view mangled_name) {
+#if defined(HAVE_GCC_ABI_DEMANGLE)
+  int status = 0;
+
+  char* demangled_name =
+      abi::__cxa_demangle(mangled_name.data(), nullptr, nullptr, &status);
+
+  if (demangled_name) {
+    std::string ret(demangled_name);
+    std::free(demangled_name);
+    return ret;
+  }
+#endif
+  return std::string(mangled_name);
+}
+
+/**
+ * @brief Demangle @p mangled_name.
+ *
+ * This function supports @c Kokkos convention from
+ * @c Kokkos::Impl::ParallelConstructName.
+ *
+ * For instance, a kernel launched with a tag would appear as
+ * "<functor type>/<tag type>".
+ */
+inline std::string demangleNameKokkos(const std::string_view mangled_name) {
+  if (size_t pos = mangled_name.find('/', 0);
+      pos != std::string_view::npos && pos > 0) {
+    /// An explicit copy of the first part of the string is needed, because
+    /// @c abi::__cxa_demangle will parse the pointer until its NULL-terminated.
+    return demangleName(std::string(mangled_name.substr(0, pos)))
+        .append("/")
+        .append(
+            demangleName(mangled_name.substr(pos + 1, mangled_name.size())));
+  } else {
+    return demangleName(mangled_name);
+  }
+}
+
+}  // namespace KokkosTools
+
+#endif  // KOKKOSTOOLS_COMMON_UTILS_DEMANGLE_HPP

--- a/profiling/simple-kernel-timer/kp_json_writer.cpp
+++ b/profiling/simple-kernel-timer/kp_json_writer.cpp
@@ -83,7 +83,7 @@ int main(int argc, char* argv[]) {
       KernelPerformanceInfo* new_kernel =
           new KernelPerformanceInfo("", PARALLEL_FOR);
       if (new_kernel->readFromFile(the_file)) {
-        if (strlen(new_kernel->getName()) > 0) {
+        if (!new_kernel->getName().empty()) {
           int kernelIndex = find_index(kernelInfo, new_kernel->getName());
 
           if (kernelIndex > -1) {

--- a/profiling/simple-kernel-timer/kp_reader.cpp
+++ b/profiling/simple-kernel-timer/kp_reader.cpp
@@ -64,7 +64,7 @@ int main(int argc, char* argv[]) {
       KernelPerformanceInfo* new_kernel =
           new KernelPerformanceInfo("", PARALLEL_FOR);
       if (new_kernel->readFromFile(the_file)) {
-        if (strlen(new_kernel->getName()) > 0) {
+        if (!new_kernel->getName().empty()) {
           int kernelIndex = find_index(kernelInfo, new_kernel->getName());
 
           if (kernelIndex > -1) {
@@ -104,7 +104,7 @@ int main(int argc, char* argv[]) {
     if (kernelInfo[i]->getKernelType() != REGION) continue;
     if (fixed_width)
       printf("- %100s\n%11s%c%15.5f%c%12" PRIu64 "%c%15.5f%c%7.3f%c%7.3f\n",
-             kernelInfo[i]->getName(),
+             kernelInfo[i]->getName().c_str(),
              (kernelInfo[i]->getKernelType() == PARALLEL_FOR)
                  ? (" (ParFor)  ")
                  : ((kernelInfo[i]->getKernelType() == PARALLEL_REDUCE)
@@ -119,7 +119,7 @@ int main(int argc, char* argv[]) {
              (kernelInfo[i]->getTime() / totalExecuteTime) * 100.0);
     else
       printf("- %s\n%s%c%f%c%" PRIu64 "%c%f%c%f%c%f\n",
-             kernelInfo[i]->getName(),
+             kernelInfo[i]->getName().c_str(),
              (kernelInfo[i]->getKernelType() == PARALLEL_FOR)
                  ? (" (ParFor)  ")
                  : ((kernelInfo[i]->getKernelType() == PARALLEL_REDUCE)
@@ -146,7 +146,7 @@ int main(int argc, char* argv[]) {
     if (kernelInfo[i]->getKernelType() == REGION) continue;
     if (fixed_width)
       printf("- %100s\n%11s%c%15.5f%c%12" PRIu64 "%c%15.5f%c%7.3f%c%7.3f\n",
-             kernelInfo[i]->getName(),
+             kernelInfo[i]->getName().c_str(),
              (kernelInfo[i]->getKernelType() == PARALLEL_FOR)
                  ? (" (ParFor)  ")
                  : ((kernelInfo[i]->getKernelType() == PARALLEL_REDUCE)
@@ -161,7 +161,7 @@ int main(int argc, char* argv[]) {
              (kernelInfo[i]->getTime() / totalExecuteTime) * 100.0);
     else
       printf("- %s\n%s%c%f%c%" PRIu64 "%c%f%c%f%c%f\n",
-             kernelInfo[i]->getName(),
+             kernelInfo[i]->getName().c_str(),
              (kernelInfo[i]->getKernelType() == PARALLEL_FOR)
                  ? (" (ParFor)  ")
                  : ((kernelInfo[i]->getKernelType() == PARALLEL_REDUCE)

--- a/profiling/simple-kernel-timer/kp_shared.h
+++ b/profiling/simple-kernel-timer/kp_shared.h
@@ -42,9 +42,9 @@ inline bool compareKernelPerformanceInfo(KernelPerformanceInfo* left,
 };
 
 inline int find_index(const std::vector<KernelPerformanceInfo*>& kernels,
-                      const char* kernelName) {
-  for (unsigned int i = 0; i < kernels.size(); i++) {
-    if (strcmp(kernels[i]->getName(), kernelName) == 0) {
+                      const std::string& kernelName) {
+  for (unsigned int i = 0; i < kernels.size(); ++i) {
+    if (kernels[i]->getName() == kernelName) {
       return i;
     }
   }

--- a/profiling/space-time-stack/kp_space_time_stack.cpp
+++ b/profiling/space-time-stack/kp_space_time_stack.cpp
@@ -31,6 +31,8 @@
 #include <algorithm>
 #include <cstring>
 
+#include "utils/demangle.hpp"
+
 #include "kp_core.hpp"
 
 #if USE_MPI
@@ -741,7 +743,7 @@ struct State {
   }
 
   void begin_frame(const char* name, StackKind kind) {
-    std::string name_str(name);
+    std::string name_str(demangleNameKokkos(name));
     stack_frame = stack_frame->get_child(std::move(name_str), kind);
     stack_frame->begin();
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(space-time-stack)

--- a/tests/space-time-stack/CMakeLists.txt
+++ b/tests/space-time-stack/CMakeLists.txt
@@ -1,0 +1,18 @@
+# A function to add such "simple" tests in 'tests/CMakeLists.txt' might be a good option.
+add_executable(test_space_time_stack_demangling)
+target_sources(
+    test_space_time_stack_demangling
+    PRIVATE
+        test_demangling.cpp
+)
+target_link_libraries(
+    test_space_time_stack_demangling
+    PRIVATE
+        Kokkos::kokkos kokkostools
+)
+add_test(
+    NAME test_space_time_stack_demangling
+    COMMAND $<TARGET_FILE:test_space_time_stack_demangling>
+        --kokkos-tools-libs=$<TARGET_FILE:kp_space_time_stack>
+        --kokkos-tools-args=1e-9
+)

--- a/tests/space-time-stack/test_demangling.cpp
+++ b/tests/space-time-stack/test_demangling.cpp
@@ -1,0 +1,80 @@
+#include <iostream>
+#include <regex>
+#include <sstream>
+
+#include "Kokkos_Core.hpp"
+
+#include "utils/demangle.hpp"
+
+struct Tester {
+  struct TagNamed {};
+  struct TagUnnamed {};
+
+  template <typename execution_space>
+  explicit Tester(const execution_space& space) {
+    //! Explicitly launch a kernel with a name and no tag.
+    Kokkos::parallel_for("named kernel",
+                         Kokkos::RangePolicy<execution_space>(space, 0, 1),
+                         *this);
+
+    //! Explicitly launch a kernel with a name and a tag.
+    Kokkos::parallel_for(
+        "named kernel with tag",
+        Kokkos::RangePolicy<execution_space, TagNamed>(space, 0, 1), *this);
+
+    //! Explicitly launch a kernel with no name and no tag.
+    Kokkos::parallel_for(Kokkos::RangePolicy<execution_space>(space, 0, 1),
+                         *this);
+
+    //! Explicitly launch a kernel with no name and a tag.
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<execution_space, TagUnnamed>(space, 0, 1), *this);
+  }
+
+  KOKKOS_FUNCTION void operator()(const int) const {}
+
+  template <typename TagType>
+  KOKKOS_FUNCTION void operator()(const TagType, const int) const {}
+};
+
+static const std::vector<std::string> matchers{
+    /// A kernel with a given name appears with the given name, no matter
+    /// if a tag was given.
+    "[0-9.e]+ sec [0-9.]+% 100.0% 0.0% ------ 1 named kernel \\[for\\]",
+    "[0-9.e]+ sec [0-9.]+% 100.0% 0.0% ------ 1 named kernel with tag "
+    "\\[for\\]",
+    //! A kernel with no name and no tag appears with a demangled name.
+    "[0-9.e]+ sec [0-9.]+% 100.0% 0.0% ------ 1 Tester \\[for\\]\n",
+    //! A kernel with no name and a tag appears with a demangled name.
+    "[0-9.e]+ sec [0-9.]+% 100.0% 0.0% ------ 1 Tester/Tester::TagUnnamed "
+    "\\[for\\]"};
+
+int main(int argc, char* argv[]) {
+  //! Initialize @c Kokkos.
+  Kokkos::initialize(argc, argv);
+
+  //! Redirect output for later analysis.
+  std::cout.flush();
+  std::ostringstream output;
+  std::streambuf* coutbuf = std::cout.rdbuf(output.rdbuf());
+
+  //! Run tests. @todo Replace this with Google Test.
+  Tester tester(Kokkos::DefaultExecutionSpace{});
+
+  //! Finalize @c Kokkos.
+  Kokkos::finalize();
+
+  //! Restore output buffer.
+  std::cout.flush();
+  std::cout.rdbuf(coutbuf);
+  std::cout << output.str() << std::endl;
+
+  //! Analyze test output.
+  for (const auto& matcher : matchers) {
+    if (!std::regex_search(output.str(), std::regex(matcher)))
+      throw std::runtime_error("Couln't find " + matcher + " in output\n" +
+                               output.str());
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
As promised in #218, this PR extracts the part relevant to demangling names.

1. The demangling function is now shared in `common/utils/demangle.hpp`.
2. The *space time stack* tool now demangles the names.

This is how the report looks like with the changes:
```bash
9: <average time> <percent of total time> <percent time in Kokkos> <percent MPI imbalance> <remainder> <kernels per second> <number of calls> <name> [type]
9: ===================
9: |-> 1.49e-02 sec 43.8% 100.0% 0.0% ------ 1 Tester<Kokkos::OpenMP, 5ul> [for]
9: |-> 1.48e-02 sec 43.5% 100.0% 0.0% ------ 2 named kernel [for]
9: |-> 4.15e-03 sec 12.2% 100.0% 0.0% ------ 1 Tester<Kokkos::OpenMP, 5ul>/Tester<Kokkos::OpenMP, 5ul>::TagUnnamed [for]
```
and how it looks without the changes:
```bash
<average time> <percent of total time> <percent time in Kokkos> <percent MPI imbalance> <remainder> <kernels per second> <number of calls> <name> [type]
===================
|-> 1.79e-02 sec 59.4% 100.0% 0.0% ------ 2 named kernel [for]
|-> 7.90e-03 sec 26.2% 100.0% 0.0% ------ 1 6TesterIN6Kokkos6OpenMPELm5EE [for]
|-> 4.20e-03 sec 13.9% 100.0% 0.0% ------ 1 6TesterIN6Kokkos6OpenMPELm5EE/N6TesterIN6Kokkos6OpenMPELm5EE10TagUnnamedE [for]
```