### PR TITLE
cleaning(simple-kernel-timer): promote `find_index` to `kp_shared.hpp`

### DIFF
--- a/profiling/simple-kernel-timer/kp_json_writer.cpp
+++ b/profiling/simple-kernel-timer/kp_json_writer.cpp
@@ -54,19 +54,6 @@ inline void write_json(std::ostream& os, KernelPerformanceInfo const& kp,
   os << indent << '}';
 }
 
-int find_index(std::vector<KernelPerformanceInfo*>& kernels,
-               const char* kernelName) {
-  for (unsigned int i = 0; i < kernels.size(); i++) {
-    KernelPerformanceInfo* nextKernel = kernels[i];
-
-    if (strcmp(nextKernel->getName(), kernelName) == 0) {
-      return i;
-    }
-  }
-
-  return -1;
-}
-
 int main(int argc, char* argv[]) {
   if (argc == 1) {
     fprintf(stderr, "Did you specify any data files on the command line!\n");

--- a/profiling/simple-kernel-timer/kp_reader.cpp
+++ b/profiling/simple-kernel-timer/kp_reader.cpp
@@ -25,19 +25,6 @@
 
 using namespace KokkosTools::KernelTimer;
 
-int find_index(std::vector<KernelPerformanceInfo*>& kernels,
-               const char* kernelName) {
-  for (unsigned int i = 0; i < kernels.size(); i++) {
-    KernelPerformanceInfo* nextKernel = kernels[i];
-
-    if (strcmp(nextKernel->getName(), kernelName) == 0) {
-      return i;
-    }
-  }
-
-  return -1;
-}
-
 int main(int argc, char* argv[]) {
   if (argc == 1) {
     fprintf(stderr, "Did you specify any data files on the command line!\n");

--- a/profiling/simple-kernel-timer/kp_shared.h
+++ b/profiling/simple-kernel-timer/kp_shared.h
@@ -19,6 +19,8 @@
 
 #include <map>
 #include <memory>
+#include <vector>
+
 #include "kp_kernel_info.h"
 
 namespace KokkosTools::KernelTimer {
@@ -38,6 +40,16 @@ inline bool compareKernelPerformanceInfo(KernelPerformanceInfo* left,
                                          KernelPerformanceInfo* right) {
   return left->getTime() > right->getTime();
 };
+
+inline int find_index(const std::vector<KernelPerformanceInfo*>& kernels,
+                      const char* kernelName) {
+  for (unsigned int i = 0; i < kernels.size(); i++) {
+    if (strcmp(kernels[i]->getName(), kernelName) == 0) {
+      return i;
+    }
+  }
+  return -1;
+}
 
 }  // namespace KokkosTools::KernelTimer
 


### PR DESCRIPTION
As suggested by @masterleinad in #225.