### PR TITLE
Use different GitHub action for indentation check

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,13 +1,11 @@
-name: Clang-Format Check
+name: Clang-Format check
 on: [push, pull_request]
 jobs:
   formatting-check:
-    name: Formatting Check
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Run clang-format style check for C/C++/Protobuf programs.
-      uses: jidicula/clang-format-action@v4.5.0
+    - name: Run clang-format style check.
+      uses: DoozyX/clang-format-lint-action@v0.16.2
       with:
-        clang-format-version: '8'
-        check-path: './'
+        clangFormatVersion: 8


### PR DESCRIPTION
As pointed out in https://github.com/kokkos/kokkos-tools/pull/227, the current GitHub Action doesn't show the diff to the desired indentation which is annoying when the correct clang-format version is not at hand. This pull requests proposes to use the same action as we do in https://github.com/kokkos/kokkos.