### PR TITLE
Minor correction to outdated folder names in build-all.sh

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -9,8 +9,8 @@ make -f $ROOT_DIR/profiling/memory-events/Makefile
 make -f $ROOT_DIR/profiling/memory-hwm/Makefile
 make -f $ROOT_DIR/profiling/memory-hwm-mpi/Makefile
 make -f $ROOT_DIR/profiling/memory-usage/Makefile
-make -f $ROOT_DIR/profiling/nvprof-connector/Makefile
-make -f $ROOT_DIR/profiling/nvprof-focused-connector/Makefile
+make -f $ROOT_DIR/profiling/nvtx-connector/Makefile
+make -f $ROOT_DIR/profiling/nvtx-focused-connector/Makefile
 make -f $ROOT_DIR/profiling/papi-connector/Makefile
 make -f $ROOT_DIR/profiling/simple-kernel-timer-json/Makefile
 make -f $ROOT_DIR/profiling/simple-kernel-timer/Makefile


### PR DESCRIPTION
I am not following this library closely, but it seems that the `nvprof-connector` and `nvprof-focused-connector` folders were renamed `nvtx-connector` and `nvtx-focused-connector`, but the `build-all.sh` script was not updated. 
https://github.com/kokkos/kokkos-tools/blob/04fe2cdc7edfbced8fa14baae385cbdb3a4b5300/build-all.sh#L12-L13