### PR TITLE
GitHub CI: Don't use rocThrust in HIP builds

### DIFF
--- a/kokkos.presets.json
+++ b/kokkos.presets.json
@@ -31,9 +31,10 @@
             "name"        : "ROCm",
             "inherits"    : "default",
             "cacheVariables" : {
-                "Kokkos_ENABLE_HIP"   : "ON",
-                "Kokkos_ARCH_VEGA906" : "ON",
-                "CMAKE_CXX_COMPILER"  : "hipcc"
+                "Kokkos_ENABLE_HIP"       : "ON",
+                "Kokkos_ENABLE_ROCTHRUST" : "OFF",
+                "Kokkos_ARCH_VEGA906"     : "ON",
+                "CMAKE_CXX_COMPILER"      : "hipcc"
             }
         }
     ],


### PR DESCRIPTION
The GitHub CI is failing since we are now expecting to find `rocThrust` for HIP by default in `Kokkos` `develop`. Fix this by not explicitly disabling support for `rocThrust`. Installing `rocThrust` would make the image too large for `GitHub` CI.