### PR TITLE
Remove tool programming interface pointer in kp_sampler_skip.cpp and kp_core.hpp

### DIFF
--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -71,7 +71,7 @@ void kokkosp_provide_tool_programming_interface(
           "KokkosP: Note: Number of functions in Tools Programming Interface "
           "is 0!\n");
   }
-  tpi_funcs = *funcsFromTPI;
+  tpi_funcs = funcsFromTPI;
 }
 
 void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,

--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -64,7 +64,7 @@ void invoke_ktools_fence(uint32_t devID) {
 }
 
 void kokkosp_provide_tool_programming_interface(
-    uint32_t num_funcs, Kokkos_Tools_ToolProgrammingInterface* funcsFromTPI) {
+    uint32_t num_funcs, Kokkos_Tools_ToolProgrammingInterface funcsFromTPI) {
   if (!num_funcs) {
     if (tool_verbosity > 0)
       printf(

--- a/profiling/all/kp_core.hpp
+++ b/profiling/all/kp_core.hpp
@@ -55,7 +55,7 @@ using Kokkos::Tools::SpaceHandle;
 #define EXPOSE_PROVIDE_TOOL_PROGRAMMING_INTERFACE(FUNC_NAME)             \
   __attribute__((weak)) void kokkosp_provide_tool_programming_interface( \
       const uint32_t num_actions,                                        \
-      Kokkos_Tools_ToolProgrammingInterface ptpi) {                     \
+      Kokkos_Tools_ToolProgrammingInterface ptpi) {                      \
     FUNC_NAME(num_actions, ptpi);                                        \
   }
 

--- a/profiling/all/kp_core.hpp
+++ b/profiling/all/kp_core.hpp
@@ -55,7 +55,7 @@ using Kokkos::Tools::SpaceHandle;
 #define EXPOSE_PROVIDE_TOOL_PROGRAMMING_INTERFACE(FUNC_NAME)             \
   __attribute__((weak)) void kokkosp_provide_tool_programming_interface( \
       const uint32_t num_actions,                                        \
-      Kokkos_Tools_ToolProgrammingInterface* ptpi) {                     \
+      Kokkos_Tools_ToolProgrammingInterface ptpi) {                     \
     FUNC_NAME(num_actions, ptpi);                                        \
   }
 


### PR DESCRIPTION
The Kokkos Core interface passes the struct by value not by pointer.