### PR TITLE
kp_kernel_logger.cpp: typo in end scan call back function 

### DIFF
--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -100,7 +100,7 @@ extern "C" void kokkosp_begin_parallel_scan(const char* name,
   printf("    %s\n", name);
 }
 
-extern "C" void kokkospk_end_parallel_scan(const uint64_t kID) {
+extern "C" void kokkosp_end_parallel_scan(const uint64_t kID) {
   printf("KokkosP: Execution of kernel %llu is completed.\n",
          (unsigned long long)(kID));
 }


### PR DESCRIPTION
The end callback for scan in kp_kernel_logger.cpp has a typo in the function.  This never broke kernel logger and didn't not cause a problem unless one used parallel_scan in their code. This causes a parent tool or tool utility to not recognize that this end callback exists when the tool utility or parent tool checks that its child library function call exists. This impacts the sampler utility and can also impact the kernel filter utility. 

In any case, this one character edit to the code file needs to be fixed as soon as possible so that Kokkos user using Kokkos Tools kernel logger sees prints of parallel_scan in their kernel_logger output. 

This is part of the original PR #213 but I am breaking that one down into small changes since there are a sizeable number and this impacts more than just the sampler.