### PR TITLE
Remove KOKKOSTOOLS_LIBRARY_MODE

### DIFF
--- a/common/kernel-filter/CMakeLists.txt
+++ b/common/kernel-filter/CMakeLists.txt
@@ -1,1 +1,1 @@
-kp_add_library(kp_kernel_filter ${KOKKOSTOOLS_LIBRARY_MODE} kp_kernel_filter.cpp)
+kp_add_library(kp_kernel_filter kp_kernel_filter.cpp)

--- a/common/kokkos-sampler/CMakeLists.txt
+++ b/common/kokkos-sampler/CMakeLists.txt
@@ -1,1 +1,1 @@
-kp_add_library(kp_kokkos_sampler ${KOKKOSTOOLS_LIBRARY_MODE} kp_sampler_skip.cpp)
+kp_add_library(kp_kokkos_sampler kp_sampler_skip.cpp)

--- a/profiling/all/CMakeLists.txt
+++ b/profiling/all/CMakeLists.txt
@@ -5,7 +5,7 @@ set(LIBNAME kokkostools)
 #  return()
 #endif()
 
-add_library(${LIBNAME} ${KOKKOSTOOLS_LIBRARY_MODE} kp_all.cpp)
+add_library(${LIBNAME} kp_all.cpp)
 
 target_include_directories(${LIBNAME}
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>


### PR DESCRIPTION
`KOKKOSTOOLS_LIBRARY_MODE` isn't a CMake variable (and not documented) and there doesn't seem much of an advantage over using the implicit `BUILD_SHARED_LIBS` option. Note that `kp_add_library` expects all extra arguments to be source files anyway so specifying `KOKKOSTOOLS_LIBRARY_MODE` wouldn't actually work.