### PR TITLE
Don't link against kokkostools in tests unconditionally

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,7 +32,7 @@ function(kp_add_executable_and_test)
     target_link_libraries(
         ${kaeat_args_TARGET_NAME}
         PRIVATE
-            kokkostools test_common
+            test_common
     )
 
     add_test(


### PR DESCRIPTION
Tests would normally just use environment variables to load the respective tool. In any case, we shouldn't link to `kokkostools` unconditionally. Tests that set the respective hooks explicitly would not use the environment variable `KOKKOS_TOOLS_LIBS` and only link against `kokkostools` that can either happen explicitly or via another argument to `kp_add_executable_and_test`.