### PR TITLE
Sampler's begin for callee's null check before fence (less overhead in corner case)

### DIFF
--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -200,7 +200,7 @@ void kokkosp_begin_parallel_for(const char* name, const uint32_t devID,
       std::cout << "KokkosP: sample " << *kID
                 << " calling child-begin function...\n";
     }
-    
+
     if (NULL != beginForCallee) {
       if (tool_globFence) {
         invoke_ktools_fence(0);

--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -200,10 +200,11 @@ void kokkosp_begin_parallel_for(const char* name, const uint32_t devID,
       std::cout << "KokkosP: sample " << *kID
                 << " calling child-begin function...\n";
     }
-    if (tool_globFence) {
-      invoke_ktools_fence(0);
-    }
+    
     if (NULL != beginForCallee) {
+      if (tool_globFence) {
+        invoke_ktools_fence(0);
+      }
       uint64_t nestedkID = 0;
       (*beginForCallee)(name, devID, &nestedkID);
       if (tool_verbosity > 0) {


### PR DESCRIPTION
This PR is simple fix involving a slight reduction in Kokkos Tools runtime overhead for one of the kokkosp_begin_parallel_xyz callbacks (done correctly for the other two); it does not raise any incorrect behavior in the develop branch version of the sampler. The callee being null is a corner case, and this reduces overhead in that case. 

Specifically, in the function `kokkosp_begin_parallel_for()`, the check of the callee pointer being null is placed after the tool-invoked fence. It should be placed _before_ the tool-invoked fence. If the child callee pointer is null, e.g., the sampler's tool-invoked fence need not be invoked. This would reduce Kokkos Tools runtime overhead. 

Note that this is consistent with @(DavidPoliakoff)'s passthrough utility draft PR. 