### PR TITLE
Check for de/allocations pointing to null

### DIFF
--- a/profiling/space-time-stack/kp_space_time_stack.cpp
+++ b/profiling/space-time-stack/kp_space_time_stack.cpp
@@ -521,14 +521,20 @@ struct Allocations {
   Allocations() : total_size(0) {}
   void allocate(std::string&& name, const void* ptr, std::uint64_t size,
                 StackNode* frame) {
-    if(ptr == nullptr) { assert(size==0); return; }
+    if (ptr == nullptr) {
+      assert(size == 0);
+      return;
+    }
     auto res = alloc_set.emplace(Allocation(std::move(name), ptr, size, frame));
     assert(res.second);
     total_size += size;
   }
   void deallocate(std::string&& name, const void* ptr, std::uint64_t size,
                   StackNode* frame) {
-    if(ptr == nullptr) { assert(size==0); return; }
+    if (ptr == nullptr) {
+      assert(size == 0);
+      return;
+    }
     auto key = Allocation(std::move(name), ptr, size, frame);
     auto it  = alloc_set.find(key);
     if (it == alloc_set.end()) {

--- a/profiling/space-time-stack/kp_space_time_stack.cpp
+++ b/profiling/space-time-stack/kp_space_time_stack.cpp
@@ -521,12 +521,14 @@ struct Allocations {
   Allocations() : total_size(0) {}
   void allocate(std::string&& name, const void* ptr, std::uint64_t size,
                 StackNode* frame) {
+    if(ptr == nullptr) { assert(size==0); return; }
     auto res = alloc_set.emplace(Allocation(std::move(name), ptr, size, frame));
     assert(res.second);
     total_size += size;
   }
   void deallocate(std::string&& name, const void* ptr, std::uint64_t size,
                   StackNode* frame) {
+    if(ptr == nullptr) { assert(size==0); return; }
     auto key = Allocation(std::move(name), ptr, size, frame);
     auto it  = alloc_set.find(key);
     if (it == alloc_set.end()) {


### PR DESCRIPTION
Fix #256. 

To address this problem showing up in LAMMPS, the allocate and deallocate functions of the Kokkos Tool library space time stack (which record and maintain in a C++ set the memory allocations in a Kokkos application) need to have a check for the case of two allocations being null. The comparison operator (<) cannot distinguish two elements in the set that are both null. 

We need to have null pointer check of the parameter `ptr`, at the beginning of allocate and deallocate function.  If the ptr variable null, then the function should simply return. 

Within this null pointer check in space-time-stack allocation and deallocate functions, we should also discern whether the size of the ptr for allocation or deallocation is greater than 0 while the ptr is null. For that reason, we put in an assert just before returning. 
