### PR TITLE
CI test with CUDA 11.0 + Perfetto connector fix (bringing PR 212 to completion)

### DIFF
--- a/.github/workflows/build-with-kokkos.yml
+++ b/.github/workflows/build-with-kokkos.yml
@@ -13,7 +13,7 @@ jobs:
           - image: ubuntu:22.04
             preset: OpenMP
             compiler: default
-          - image: nvidia/cuda:11.0.3-base-ubuntu20.04
+          - image: nvidia/cuda:12.1.0-devel-ubuntu22.04
             preset: Cuda
             compiler: default
           - image: nvidia/cuda:12.2.0-devel-ubuntu22.04

--- a/.github/workflows/build-with-kokkos.yml
+++ b/.github/workflows/build-with-kokkos.yml
@@ -13,7 +13,7 @@ jobs:
           - image: ubuntu:22.04
             preset: OpenMP
             compiler: default
-          - image: nvidia/cuda:12.1.0-devel-ubuntu22.04
+          - image: nvidia/cuda:11.0.3-devel-ubuntu20.04
             preset: Cuda
             compiler: default
           - image: nvidia/cuda:12.2.0-devel-ubuntu22.04
@@ -38,6 +38,9 @@ jobs:
           repository: kokkos/kokkos
           path: kokkos
           ref: develop
+      - name: Ensure non-interactive frontend.
+        run : |
+          echo "DEBIAN_FRONTEND=noninteractive" >> $GITHUB_ENV
       - name: Install compilers
         run : |
           apt update
@@ -70,6 +73,18 @@ jobs:
                   echo "Unsupported preset '${{ matrix.preset }}'."
                   exit -1
           esac
+
+      # Add Kitware's APT source to get the latest CMake version (or at least newer than 3.19 to support JSON presets).
+      # See also https://apt.kitware.com/.
+      - name: Add Kitware's APT source to get the latest CMake version.
+        run : |
+          apt --yes --no-install-recommends install wget lsb-release ca-certificates gnupg
+          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+          echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+          apt update
+          rm /usr/share/keyrings/kitware-archive-keyring.gpg
+          apt --no-install-recommends --yes install kitware-archive-keyring
+          apt policy cmake
 
       - name: Install CMake, OpenMPI and dtrace
         run: |

--- a/.github/workflows/build-with-kokkos.yml
+++ b/.github/workflows/build-with-kokkos.yml
@@ -15,7 +15,7 @@ jobs:
             compiler: default
           - image: nvidia/cuda:11.0.3-devel-ubuntu20.04
             preset: Cuda
-            compiler: default
+            compiler: {cpp: g++-11, c: gcc-11}
           - image: nvidia/cuda:12.2.0-devel-ubuntu22.04
             preset: Cuda
             compiler: {cpp: g++-12, c: gcc-12}

--- a/.github/workflows/build-with-kokkos.yml
+++ b/.github/workflows/build-with-kokkos.yml
@@ -13,7 +13,7 @@ jobs:
           - image: ubuntu:22.04
             preset: OpenMP
             compiler: default
-          - image: nvidia/cuda:12.1.0-devel-ubuntu22.04
+          - image: nvidia/cuda:11.0.3-devel-ubuntu20.04
             preset: Cuda
             compiler: default
           - image: nvidia/cuda:12.2.0-devel-ubuntu22.04
@@ -38,6 +38,9 @@ jobs:
           repository: kokkos/kokkos
           path: kokkos
           ref: develop
+      - name: Ensure non-interactive frontend.
+        run : |
+          echo "DEBIAN_FRONTEND=noninteractive" >> $GITHUB_ENV
       - name: Install compilers
         run : |
           apt update
@@ -70,6 +73,18 @@ jobs:
                   echo "Unsupported preset '${{ matrix.preset }}'."
                   exit -1
           esac
+
+      # Add Kitware's APT source to get the latest CMake version (or at least newer than 3.19 to support JSON presets).
+      # See also https://apt.kitware.com/.
+      - name: Add Kitware's APT source to get the latest CMake version.
+        run : |
+          apt --yes --no-install-recommends install wget lsb-release ca-certificates gnupg
+          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+          echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+          apt update
+          rm /usr/share/keyrings/kitware-archive-keyring.gpg
+          apt --no-install-recommends --yes install kitware-archive-keyring
+          apt policy cmake
 
       - name: Install git, CMake, OpenMPI, PAPI and dtrace
         run: |

--- a/.github/workflows/build-with-kokkos.yml
+++ b/.github/workflows/build-with-kokkos.yml
@@ -86,12 +86,14 @@ jobs:
           apt --no-install-recommends --yes install kitware-archive-keyring
           apt policy cmake
 
-      - name: Install CMake, OpenMPI and dtrace
+      - name: Install git, CMake, OpenMPI, PAPI and dtrace
         run: |
           apt --yes --no-install-recommends install \
+            git ca-certificates \
             cmake make \
             libopenmpi-dev \
-            systemtap-sdt-dev
+            systemtap-sdt-dev \
+            libpapi-dev
       - name: Compile and install Kokkos
         working-directory: kokkos
         run: |

--- a/.github/workflows/build-with-kokkos.yml
+++ b/.github/workflows/build-with-kokkos.yml
@@ -13,7 +13,7 @@ jobs:
           - image: ubuntu:22.04
             preset: OpenMP
             compiler: default
-          - image: nvidia/cuda:11.0.3-devel-ubuntu20.04
+          - image: nvidia/cuda:11.0.3-base-ubuntu20.04
             preset: Cuda
             compiler: default
           - image: nvidia/cuda:12.2.0-devel-ubuntu22.04

--- a/.github/workflows/build-with-kokkos.yml
+++ b/.github/workflows/build-with-kokkos.yml
@@ -15,7 +15,7 @@ jobs:
             compiler: default
           - image: nvidia/cuda:11.0.3-devel-ubuntu20.04
             preset: Cuda
-            compiler: {cpp: g++-12, c: gcc-12}
+            compiler: default
           - image: nvidia/cuda:12.2.0-devel-ubuntu22.04
             preset: Cuda
             compiler: {cpp: g++-12, c: gcc-12}

--- a/.github/workflows/build-with-kokkos.yml
+++ b/.github/workflows/build-with-kokkos.yml
@@ -15,7 +15,7 @@ jobs:
             compiler: default
           - image: nvidia/cuda:11.0.3-devel-ubuntu20.04
             preset: Cuda
-            compiler: {cpp: g++-11, c: gcc-11}
+            compiler: {cpp: g++-12, c: gcc-12}
           - image: nvidia/cuda:12.2.0-devel-ubuntu22.04
             preset: Cuda
             compiler: {cpp: g++-12, c: gcc-12}

--- a/kokkos.presets.json
+++ b/kokkos.presets.json
@@ -33,6 +33,7 @@
             "cacheVariables" : {
                 "Kokkos_ENABLE_HIP"   : "ON",
                 "Kokkos_ARCH_VEGA906" : "ON",
+                "Kokkos_ENABLE_ROCTHRUST" : "OFF",
                 "CMAKE_CXX_COMPILER"  : "hipcc"
             }
         }

--- a/profiling/perfetto-connector/perfetto/perfetto.cc
+++ b/profiling/perfetto-connector/perfetto/perfetto.cc
@@ -2472,7 +2472,7 @@ void InstallCtrCHandler(CtrlCHandlerFunction);
 /*
  * Copyright (C) 2021 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");InlineChunkHeaderSize'
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/profiling/perfetto-connector/perfetto/perfetto.cc
+++ b/profiling/perfetto-connector/perfetto/perfetto.cc
@@ -2472,7 +2472,7 @@ void InstallCtrCHandler(CtrlCHandlerFunction);
 /*
  * Copyright (C) 2021 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License");InlineChunkHeaderSize'
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -49250,7 +49250,7 @@ class TracePacket;
 // ReadNextTracePacket() below.
 class TraceBuffer {
  public:
-  static const size_t InlineChunkHeaderSize;  // For test/fake_packet.{cc,h}.
+  static constexpr size_t InlineChunkHeaderSize = sizeof(ChunkRecord);  // For test/fake_packet.{cc,h}.
 
   // See comment in the header above.
   enum OverwritePolicy { kOverwrite, kDiscard };

--- a/profiling/perfetto-connector/perfetto/perfetto.cc
+++ b/profiling/perfetto-connector/perfetto/perfetto.cc
@@ -49250,7 +49250,7 @@ class TracePacket;
 // ReadNextTracePacket() below.
 class TraceBuffer {
  public:
-  static constexpr size_t InlineChunkHeaderSize = sizeof(ChunkRecord);  // For test/fake_packet.{cc,h}.
+  static const size_t InlineChunkHeaderSize = sizeof(ChunkRecord);  // For test/fake_packet.{cc,h}.
 
   // See comment in the header above.
   enum OverwritePolicy { kOverwrite, kDiscard };
@@ -49830,7 +49830,7 @@ constexpr uint8_t kChunkNeedsPatching =
 }  // namespace.
 
 constexpr size_t TraceBuffer::ChunkRecord::kMaxSize;
-constexpr size_t TraceBuffer::InlineChunkHeaderSize = sizeof(ChunkRecord);
+const size_t TraceBuffer::InlineChunkHeaderSize;
 
 // static
 std::unique_ptr<TraceBuffer> TraceBuffer::Create(size_t size_in_bytes,

--- a/profiling/perfetto-connector/perfetto/perfetto.cc
+++ b/profiling/perfetto-connector/perfetto/perfetto.cc
@@ -49250,7 +49250,7 @@ class TracePacket;
 // ReadNextTracePacket() below.
 class TraceBuffer {
  public:
-  static const size_t InlineChunkHeaderSize = sizeof(ChunkRecord);  // For test/fake_packet.{cc,h}.
+  static const size_t InlineChunkHeaderSize;  // For test/fake_packet.{cc,h}.
 
   // See comment in the header above.
   enum OverwritePolicy { kOverwrite, kDiscard };
@@ -49830,7 +49830,7 @@ constexpr uint8_t kChunkNeedsPatching =
 }  // namespace.
 
 constexpr size_t TraceBuffer::ChunkRecord::kMaxSize;
-const size_t TraceBuffer::InlineChunkHeaderSize;
+const size_t TraceBuffer::InlineChunkHeaderSize = sizeof(ChunkRecord);
 
 // static
 std::unique_ptr<TraceBuffer> TraceBuffer::Create(size_t size_in_bytes,


### PR DESCRIPTION
This PR is a continuation of PR #212, based on review and fixes of that PR and trying to address an associated problem /bug with Perfetto connector that is invoked when using CUDA-11.0, as discussed with @crtrott. 

Note that the problem is from perfetto/perfetto.cc and not the Perfetto Kokkos Tools connector. 

This PR also may address a Kokkos Tools Issue #259 from a Kokkos Tools user, but more discussion with the user is needed to see if it does fix it for their setup/environment/compilers that they are using for Perfetto.