### PR TITLE
add "=" between --kokkos-tools-args and argument

### DIFF
--- a/profiling/space-time-stack/kp_space_time_stack.cpp
+++ b/profiling/space-time-stack/kp_space_time_stack.cpp
@@ -913,9 +913,9 @@ Description:
 
 Example:
   The following example would set the threshold to 10%
-    <exe> [--kokkos-tools-args 10 ]
+    <exe> [--kokkos-tools-args=10 ]
 )usage";
-  std::cout << "usage: " << exe << "[--kokkos-tools-args <threshold>]\n"
+  std::cout << "usage: " << exe << "[--kokkos-tools-args=<threshold>]\n"
             << usage;
 }
 


### PR DESCRIPTION
A user at LANL tried `--kokkos-tools-args 10` and received an error during `Kokkos::initialize()`. They needed to do `--kokkos-tools-args=10`