### PR TITLE
[WIP] Prevent perfetto-connector from breaking Kokkos Tools CI

### DIFF
--- a/profiling/perfetto-connector/perfetto/perfetto.cc
+++ b/profiling/perfetto-connector/perfetto/perfetto.cc
@@ -49830,7 +49830,7 @@ constexpr uint8_t kChunkNeedsPatching =
 }  // namespace.
 
 constexpr size_t TraceBuffer::ChunkRecord::kMaxSize;
-constexpr size_t TraceBuffer::InlineChunkHeaderSize = sizeof(ChunkRecord);
+const size_t TraceBuffer::InlineChunkHeaderSize = sizeof(ChunkRecord);
 
 // static
 std::unique_ptr<TraceBuffer> TraceBuffer::Create(size_t size_in_bytes,


### PR DESCRIPTION
Fix problem with chunk size that occurs with different compile time configurations. This is expected to fix Kokkos Tools Issue #259. 

This PR is part of an effort to breaks down PR #262 into two separate pieces. This piece focuses on the Perfetto connector fix, while the other is on allowing for Debian interactive mode and ensuring the latest versions of CMake.