### PR TITLE
Memory Usage: Add memory transferred between Kokkos Mem Spaces

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,84 @@
+# Copilot Instructions for kokkos-tools
+
+These notes teach AI coding agents how to be productive in this repo quickly: where things live, how they build, and the key patterns for integrating new tools or connectors.
+
+## Big picture
+
+- Purpose: A suite of lightweight profiling/debugging tools for Kokkos applications, loaded via Kokkos profiling hooks. Agents typically implement or modify a tool (profiler/connector) as a shared library and run it by setting `KOKKOS_TOOLS_LIBS`.
+- Architecture:
+  - Root CMake (`CMakeLists.txt`) orchestrates optional subprojects under `common/`, `debugging/`, and `profiling/`.
+  - Each tool is an independent shared lib built from its subdirectory via CMake or local Makefiles.
+  - Optional monolithic "single" library (`profiling/all/`) can dispatch multiple profilers at runtime when `KokkosTools_ENABLE_SINGLE=ON`.
+  - Common headers are generated to `bld/common/kp_config.hpp` from `common/kp_config.hpp.in` and included via `COMMON_HEADERS_PATH`.
+  - External integrations (PAPI, VTune, NVTX, ROCTX, Caliper, Variorum, MPI) are conditionally discovered/added by CMake.
+
+## Key directories
+
+- `common/` — shared utilities and helper tools
+  - `kernel-filter/` and `kokkos-sampler/` are opt-in utilities that gate or sample profiling.
+- `debugging/kernel-logger/` — prints Kokkos kernel/region events.
+- `profiling/` — the main profiler/connectors collection (memory tools, tracing, GPU/third-party connectors).
+- `example/` — small example using the monolithic interface when `KokkosTools_ENABLE_SINGLE=ON`.
+- `tests/` — gtest-based tests, gated by `KokkosTools_ENABLE_TESTS`.
+- `cmake/` — helper modules (Kokkos config discovery, TPLs, Apex/git submodule, utilities).
+
+## Build workflows
+
+- CMake (recommended for full suite):
+  - From a fresh build dir: `cmake .. [-DKokkosTools_ENABLE_*=ON/OFF]` then `make` and optionally `make install`.
+  - Kokkos detection and reuse: `-DKokkosTools_REUSE_KOKKOS_COMPILER=ON` reuses Kokkos' compiler/standard. Requires Kokkos to be discoverable.
+  - Toggle profilers/connectors by options in `CMakeLists.txt`:
+    - `KokkosTools_ENABLE_PAPI`, `KokkosTools_ENABLE_MPI`, `KokkosTools_ENABLE_CALIPER`, `KokkosTools_ENABLE_APEX`, `KokkosTools_ENABLE_SINGLE`, `KokkosTools_ENABLE_EXAMPLES`, `KokkosTools_ENABLE_TESTS`.
+  - macOS specific: shared libs are `.dylib`. On Linux they are `.so`.
+- Makefile (fast per-tool build): `cd <tool dir> && make` builds the local shared lib.
+- Generated headers: `common/kp_config.hpp` is configured during CMake; avoid committing generated files.
+
+## Running tools
+
+- Set env var with one or more libraries:
+  - `KOKKOS_TOOLS_LIBS=/path/to/lib<tool>.so` (Linux) or `.dylib` (macOS).
+  - Some docs refer to `KOKKOS_TOOLS_LIBRARY`; this repo uses `KOKKOS_TOOLS_LIBS` in README. Keep consistency in new docs and examples.
+- Ensure your Kokkos app is built with `Kokkos_ENABLE_LIBDL=ON` (typical default) so hooks load dynamically.
+
+## Patterns when adding a new tool
+
+- Subdirectory layout mirrors existing tools:
+  - Create `profiling/<my-tool>/` (or `debugging/<...>/`) with `CMakeLists.txt` and source files.
+  - Export target with `install(TARGETS ...)` so users can `make install`.
+  - Include `common` and `profiling/all` headers as needed; most tools include `profiling/all/kp_core.hpp` or related hook headers.
+- Hook usage:
+  - Implement Kokkos profiling callbacks (e.g., begin/end kernel, memory alloc/free) in your lib and register on load.
+  - Use labels provided by Kokkos constructs for kernel-centric analysis; follow examples like `simple-kernel-timer`, `memory-usage`, `kernel-logger`.
+- Conditional availability:
+  - Gate platform-specific integrations (NVTX on CUDA, ROCTX on HIP) with CMake `if(Kokkos_ENABLE_CUDA)` / `if(Kokkos_ENABLE_HIP)`.
+  - Third-party connectors should `find_package(...)` or rely on env variables (e.g., `VTUNE_HOME`).
+
+## Conventions and gotchas
+
+- No in-source builds: CMake hard-errors if `CMAKE_SOURCE_DIR == CMAKE_BINARY_DIR`.
+- Respect `BUILD_SHARED_LIBS` and Apple/Windows switches in root CMake.
+- Monolithic vs. per-tool:
+  - Monolithic single-lib (`profiling/all/`) requires `KokkosTools_ENABLE_SINGLE=ON`; examples and some tests assume this.
+- MPI support toggled via `KokkosTools_ENABLE_MPI`; memory-hwm-mpi is conditionally built.
+- Some connectors (systemtap) require `dtrace` (Unix-only) and are skipped if not present.
+
+## Examples in repo
+
+- `debugging/kernel-logger/kp_kernel_logger.cpp` — demonstrates region and kernel start/stop callbacks.
+- `profiling/simple-kernel-timer/` — minimal timing of kernel events.
+- `common/kernel-filter/` — shows how to gate tools to specific kernels.
+
+## Testing & CI hooks
+
+- Tests: enable via `-DKokkosTools_ENABLE_TESTS=ON`; gtest setup is under `cmake/BuildGTest.cmake` and `tests/`.
+- Examples: enable via `-DKokkosTools_ENABLE_EXAMPLES=ON`; note warning if single-lib is disabled.
+
+## Debugging tips
+
+- Verify the tool is loaded: print a log on library init; check `KOKKOS_TOOLS_LIBS` path and file extension.
+- On macOS, prefer absolute paths for `.dylib` in `KOKKOS_TOOLS_LIBS`.
+- Cross-check that Kokkos app has profiling hooks enabled and `LIBDL` support.
+
+---
+
+Questions or unclear sections? Tell us which workflows or directories you’d like more detail on (e.g., perfetto/chrome tracing setup, PAPI connector versions, or single-library dispatch), and we’ll refine these instructions.

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -152,7 +152,6 @@ void kokkosp_begin_deep_copy(SpaceHandle dst_handle, const char* dst_name,
     strncpy(space_name[num_spaces], dst_handle.name, 64);
     num_spaces++;
   }
-
   
   int space_src = num_spaces;
   for (int s = 0; s < num_spaces; s++)

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -142,10 +142,10 @@ void kokkosp_deallocate_data(const SpaceHandle space, const char* /*label*/,
   }
 }
 
-void kokkosp_begin_deep_copy(SpaceHandle dst_handle, const char* dst_name,
-                             const void* dst_ptr, SpaceHandle src_handle,
-                             const char* src_name, const void* src_ptr,
-                             uint64_t size) {
+void kokkosp_begin_deep_copy(SpaceHandle dst_handle, const char* /* dst_name */,
+                             const void* /* dst_ptr */, SpaceHandle src_handle,
+                             const char* /* src_name */,
+                             const void* /* src_ptr */, uint64_t size) {
   std::lock_guard<std::mutex> lock(m);
 
   int space_dst = num_spaces;

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -94,7 +94,7 @@ void kokkosp_finalize_library() {
     fprintf(ofile, "--- Data transferred between Kokkos Memory Spaces (MB) --- \n"); 
    for (unsigned int dst = 0; dst < num_spaces; dst++) {
         for (unsigned int src = 0; src < num_spaces; src++) {
-      fprintf(ofile, "%s %s %llu \n", space_name[dst], space_name[src], totalMemoryTransferred[dst][src]);
+      fprintf(ofile, "%s %s %.1lf \n", space_name[dst], space_name[src], 1.0 * totalMemoryTransferred[dst][src] / 1024 / 1024);
       totalMemorySpaceDataTransfer += totalMemoryTransferred[dst][src]; 
      }
    }

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -88,10 +88,10 @@ void kokkosp_finalize_library() {
               1.0 * std::get<2>(space_size_track[s][i]) / 1024 / 1024);
     }
 
-    fprintf(ofile,
-            "--- Data transferred between Kokkos Memory Spaces (MB) --- \n");
+    fprintf(ofile, "# Data transferred between Kokkos Memory Spaces --- \n");
     for (unsigned int dst = 0; dst < (unsigned int)num_spaces; dst++) {
       for (unsigned int src = 0; src < (unsigned int)num_spaces; src++) {
+        fprintf(ofile, "# DstSpace     SrcSpace    Data-Transferred(MB)\n");
         fprintf(ofile, "%s %s %.1lf \n", space_name[dst], space_name[src],
                 1.0 * totalMemoryTransferred[dst][src] / 1024 / 1024);
       }

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -62,8 +62,7 @@ void kokkosp_init_library(const int /*loadSeq*/,
 }
 
 void kokkosp_finalize_library() {
-  uint64_t totalMemorySpaceDataTransfer = 0;
-  char* hostname                        = (char*)malloc(sizeof(char) * 256);
+  char* hostname = (char*)malloc(sizeof(char) * 256);
   gethostname(hostname, 256);
   int pid = getpid();
 
@@ -95,13 +94,8 @@ void kokkosp_finalize_library() {
       for (unsigned int src = 0; src < num_spaces; src++) {
         fprintf(ofile, "%s %s %.1lf \n", space_name[dst], space_name[src],
                 1.0 * totalMemoryTransferred[dst][src] / 1024 / 1024);
-        totalMemorySpaceDataTransfer += totalMemoryTransferred[dst][src];
       }
     }
-
-    fprintf(ofile,
-            "Total Memory Transferred across all Kokkos Memory Spaces (MB): %.1lf \n",
-            1.0 * totalMemorySpaceDataTransfer / 1024 / 1024);
 
     fclose(ofile);
   }

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -89,8 +89,8 @@ void kokkosp_finalize_library() {
     }
 
     fprintf(ofile, "# Data transferred between Kokkos Memory Spaces --- \n");
-    for (unsigned int dst = 0; dst < (unsigned int)num_spaces; dst++) {
-      for (unsigned int src = 0; src < (unsigned int)num_spaces; src++) {
+    for (int dst = 0; dst < num_spaces; dst++) {
+      for (int src = 0; src < num_spaces; src++) {
         fprintf(ofile, "# DstSpace     SrcSpace    Data-Transferred(MB)\n");
         fprintf(ofile, "%s %s %.1lf \n", space_name[dst], space_name[src],
                 1.0 * totalMemoryTransferred[dst][src] / 1024 / 1024);

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -35,7 +35,7 @@ char space_name[16][64];
 int num_spaces;
 std::vector<std::tuple<double, uint64_t, double> > space_size_track[16];
 uint64_t space_size[16];
-uint64_t totalMemoryTransferred;
+uint64_t totalMemoryTransferred[16][16];
 static std::mutex m;
 
 Kokkos::Timer timer;
@@ -52,8 +52,13 @@ void kokkosp_init_library(const int /*loadSeq*/,
                           const uint32_t /*devInfoCount*/,
                           Kokkos_Profiling_KokkosPDeviceInfo* /*deviceInfo*/) {
   num_spaces = 0;
-  for (int i = 0; i < 16; i++) space_size[i] = 0;
-  totalMemoryTransferred = 0;
+  for (int i = 0; i < 16; i++) { 
+    space_size[i] = 0;
+    for (int j = 0; j < 16; j++) 
+     { 
+      totalMemoryTransferred[i][j] = 0;
+     } 
+  } 
   timer.reset();
 }
 
@@ -83,7 +88,11 @@ void kokkosp_finalize_library() {
               1.0 * maxvalue / 1024 / 1024,
               1.0 * std::get<2>(space_size_track[s][i]) / 1024 / 1024);
     }
-    fprintf(ofile, "\n \n Total Memory Transferred: %.1lf \t", totalMemoryTransferred);
+   for (unsigned int dst = 0; dst < num_spaces; dst++) {
+        for (unsigned int src = 0; src < num_spaces; src++) {
+      fprintf(ofile, "%s %s %.1lf \n", space_name[dst], space_name[src], totalMemoryTransferred[dst][src]);
+     } 
+   }
     fclose(ofile);
   }
   free(hostname);
@@ -134,7 +143,26 @@ void kokkosp_begin_deep_copy(SpaceHandle dst_handle, const char* dst_name,
                              const char* src_name, const void* src_ptr,
                              uint64_t size) {
   std::lock_guard<std::mutex> lock(m);
-  totalMemoryTransferred += size;
+
+  int space_dst = num_spaces;
+  for (int s = 0; s < num_spaces; s++)
+    if (strcmp(space_name[s], dst_handle.name) == 0) space_dst = s;
+
+  if (space_dst == num_spaces) {
+    strncpy(space_name[num_spaces], dst_handle.name, 64);
+    num_spaces++;
+  }
+
+  
+  int space_src = num_spaces;
+  for (int s = 0; s < num_spaces; s++)
+    if (strcmp(space_name[s], src_handle.name) == 0) space_src = s;
+
+  if (space_src == num_spaces) {
+    strncpy(space_name[num_spaces], src_handle.name, 64);
+    num_spaces++;
+  }
+  totalMemoryTransferred[space_dst][space_src] += size;
 }
 
 

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -100,8 +100,9 @@ void kokkosp_finalize_library() {
     }
 
     fprintf(ofile,
-            "Total Memory Transferred across all Kokkos Memory Spaces: %llu \n",
-            totalMemorySpaceDataTransfer);
+            "Total Memory Transferred across all Kokkos Memory Spaces (MB): %.1lf \n",
+            1.0 * totalMemorySpaceDataTransfer / 1024 / 1024);
+
     fclose(ofile);
   }
   free(hostname);

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -83,7 +83,7 @@ void kokkosp_finalize_library() {
               1.0 * maxvalue / 1024 / 1024,
               1.0 * std::get<2>(space_size_track[s][i]) / 1024 / 1024);
     }
-    fprintf(ofile, "\n \n Total Memory Transferred: %.1lf \t", totalMemoryTransferred);
+    fprintf(ofile, "\n \n Total Memory Transferred: %llu \t", totalMemoryTransferred);
     fclose(ofile);
   }
   free(hostname);

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -35,7 +35,7 @@ char space_name[16][64];
 int num_spaces;
 std::vector<std::tuple<double, uint64_t, double> > space_size_track[16];
 uint64_t space_size[16];
-
+uint64_t totalMemoryTransferred;
 static std::mutex m;
 
 Kokkos::Timer timer;
@@ -53,7 +53,7 @@ void kokkosp_init_library(const int /*loadSeq*/,
                           Kokkos_Profiling_KokkosPDeviceInfo* /*deviceInfo*/) {
   num_spaces = 0;
   for (int i = 0; i < 16; i++) space_size[i] = 0;
-
+  totalMemoryTransferred = 0;
   timer.reset();
 }
 
@@ -83,6 +83,7 @@ void kokkosp_finalize_library() {
               1.0 * maxvalue / 1024 / 1024,
               1.0 * std::get<2>(space_size_track[s][i]) / 1024 / 1024);
     }
+    fprintf(ofile, "\n \n Total Memory Transferred: %.1lf \t", totalMemoryTransferred);
     fclose(ofile);
   }
   free(hostname);
@@ -128,6 +129,20 @@ void kokkosp_deallocate_data(const SpaceHandle space, const char* /*label*/,
   }
 }
 
+void kokkosp_begin_deep_copy(SpaceHandle dst_handle, const char* dst_name,
+                             const void* dst_ptr, SpaceHandle src_handle,
+                             const char* src_name, const void* src_ptr,
+                             uint64_t size) {
+  std::lock_guard<std::mutex> lock(m);
+  totalMemoryTransferred += size;
+}
+
+
+void kokkosp_end_deep_copy() {
+  std::lock_guard<std::mutex> lock(m);
+  // TODO: pop the last xfer space
+}
+
 Kokkos::Tools::Experimental::EventSet get_event_set() {
   Kokkos::Tools::Experimental::EventSet my_event_set;
   memset(&my_event_set, 0,
@@ -136,6 +151,8 @@ Kokkos::Tools::Experimental::EventSet get_event_set() {
   my_event_set.finalize        = kokkosp_finalize_library;
   my_event_set.allocate_data   = kokkosp_allocate_data;
   my_event_set.deallocate_data = kokkosp_deallocate_data;
+  my_event_set.begin_deep_copy = kokkosp_begin_deep_copy;
+  my_event_set.end_deep_copy   = kokkosp_end_deep_copy;
   return my_event_set;
 }
 
@@ -150,5 +167,7 @@ EXPOSE_INIT(impl::kokkosp_init_library)
 EXPOSE_FINALIZE(impl::kokkosp_finalize_library)
 EXPOSE_ALLOCATE(impl::kokkosp_allocate_data)
 EXPOSE_DEALLOCATE(impl::kokkosp_deallocate_data)
+EXPOSE_BEGIN_DEEP_COPY(impl::kokkosp_begin_deep_copy)
+EXPOSE_END_DEEP_COPY(impl::kokkosp_end_deep_copy)
 
 }  // extern "C"

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -90,8 +90,8 @@ void kokkosp_finalize_library() {
 
     fprintf(ofile,
             "--- Data transferred between Kokkos Memory Spaces (MB) --- \n");
-    for (unsigned int dst = 0; dst < num_spaces; dst++) {
-      for (unsigned int src = 0; src < num_spaces; src++) {
+    for (unsigned int dst = 0; dst < (unsigned int) num_spaces; dst++) {
+      for (unsigned int src = 0; src < (unsigned int) num_spaces; src++) {
         fprintf(ofile, "%s %s %.1lf \n", space_name[dst], space_name[src],
                 1.0 * totalMemoryTransferred[dst][src] / 1024 / 1024);
       }

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -58,7 +58,7 @@ void kokkosp_init_library(const int /*loadSeq*/,
      { 
       totalMemoryTransferred[i][j] = 0;
      } 
-  } 
+  }
   timer.reset();
 }
 
@@ -88,10 +88,12 @@ void kokkosp_finalize_library() {
               1.0 * maxvalue / 1024 / 1024,
               1.0 * std::get<2>(space_size_track[s][i]) / 1024 / 1024);
     }
+
+  fprintf(ofile, "--- Memory transferred between Kokkos Memory Spaces --- \n"); 
    for (unsigned int dst = 0; dst < num_spaces; dst++) {
         for (unsigned int src = 0; src < num_spaces; src++) {
       fprintf(ofile, "%s %s %.1lf \n", space_name[dst], space_name[src], totalMemoryTransferred[dst][src]);
-     } 
+     }
    }
     fclose(ofile);
   }

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -67,12 +67,18 @@ void kokkosp_finalize_library() {
   int pid = getpid();
 
   for (int s = 0; s < num_spaces; s++) {
-    char* fileOutput = (char*)malloc(sizeof(char) * 256);
+
+    char* fileOutput = (char*)malloc(sizeof(char) * 256); 
+    char* fileOutputxfers = (char*)malloc(sizeof(char) * 256);
+
     snprintf(fileOutput, 256, "%s-%d-%s.memspace_usage", hostname, pid,
              space_name[s]);
-
+    
+    snprintf(fileOutputxfers, 256, "%s-%d.memspace_transfers", hostname, pid);
     FILE* ofile = fopen(fileOutput, "wb");
+    FILE* ofilexf = fopen(fileOutputxfers, "wb");
     free(fileOutput);
+    free(fileOutputxfers);
 
     fprintf(ofile, "# Space %s\n", space_name[s]);
     fprintf(ofile,
@@ -88,11 +94,11 @@ void kokkosp_finalize_library() {
               1.0 * std::get<2>(space_size_track[s][i]) / 1024 / 1024);
     }
 
-    fprintf(ofile, "# Data transferred between Kokkos Memory Spaces --- \n");
+    fprintf(ofilexf, "# Data transferred between Kokkos Memory Spaces --- \n");
     for (int dst = 0; dst < num_spaces; dst++) {
       for (int src = 0; src < num_spaces; src++) {
-        fprintf(ofile, "# DstSpace     SrcSpace    Data-Transferred(MB)\n");
-        fprintf(ofile, "%s %s %.1lf \n", space_name[dst], space_name[src],
+        fprintf(ofilexf, "# DstSpace     SrcSpace    Data-Transferred(MB)\n");
+        fprintf(ofilexf, "%s %s %.1lf \n", space_name[dst], space_name[src],
                 1.0 * totalMemoryTransferred[dst][src] / 1024 / 1024);
       }
     }
@@ -168,7 +174,7 @@ void kokkosp_begin_deep_copy(SpaceHandle dst_handle, const char* /* dst_name */,
   totalMemoryTransferred[space_dst][space_src] += size;
 }
 
-void kokkosp_end_deep_copy() { std::lock_guard<std::mutex> lock(m); }
+void kokkosp_end_deep_copy() { }
 
 Kokkos::Tools::Experimental::EventSet get_event_set() {
   Kokkos::Tools::Experimental::EventSet my_event_set;

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -90,8 +90,8 @@ void kokkosp_finalize_library() {
 
     fprintf(ofile,
             "--- Data transferred between Kokkos Memory Spaces (MB) --- \n");
-    for (unsigned int dst = 0; dst < (unsigned int) num_spaces; dst++) {
-      for (unsigned int src = 0; src < (unsigned int) num_spaces; src++) {
+    for (unsigned int dst = 0; dst < (unsigned int)num_spaces; dst++) {
+      for (unsigned int src = 0; src < (unsigned int)num_spaces; src++) {
         fprintf(ofile, "%s %s %.1lf \n", space_name[dst], space_name[src],
                 1.0 * totalMemoryTransferred[dst][src] / 1024 / 1024);
       }

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -67,15 +67,14 @@ void kokkosp_finalize_library() {
   int pid = getpid();
 
   for (int s = 0; s < num_spaces; s++) {
-
-    char* fileOutput = (char*)malloc(sizeof(char) * 256); 
+    char* fileOutput      = (char*)malloc(sizeof(char) * 256);
     char* fileOutputxfers = (char*)malloc(sizeof(char) * 256);
 
     snprintf(fileOutput, 256, "%s-%d-%s.memspace_usage", hostname, pid,
              space_name[s]);
-    
+
     snprintf(fileOutputxfers, 256, "%s-%d.memspace_transfers", hostname, pid);
-    FILE* ofile = fopen(fileOutput, "wb");
+    FILE* ofile   = fopen(fileOutput, "wb");
     FILE* ofilexf = fopen(fileOutputxfers, "wb");
     free(fileOutput);
     free(fileOutputxfers);
@@ -174,7 +173,7 @@ void kokkosp_begin_deep_copy(SpaceHandle dst_handle, const char* /* dst_name */,
   totalMemoryTransferred[space_dst][space_src] += size;
 }
 
-void kokkosp_end_deep_copy() { }
+void kokkosp_end_deep_copy() {}
 
 Kokkos::Tools::Experimental::EventSet get_event_set() {
   Kokkos::Tools::Experimental::EventSet my_event_set;

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -94,9 +94,11 @@ void kokkosp_finalize_library() {
     }
 
     fprintf(ofile, "# Data transferred between Kokkos Memory Spaces --- \n");
-    for (unsigned int dst = 0; (unsigned int) dst < num_spaces; dst++) {
-      for (unsigned int src = 0; (unsigned int) src < num_spaces; src++) {
-        fprintf(ofile, "# Dst Mem Space     Src Mem Space    Total Data-Transferred(MB)\n");
+    for (unsigned int dst = 0; (unsigned int)dst < num_spaces; dst++) {
+      for (unsigned int src = 0; (unsigned int)src < num_spaces; src++) {
+        fprintf(ofile,
+                "# Dst Mem Space     Src Mem Space    Total "
+                "Data-Transferred(MB)\n");
         fprintf(ofile, "%s %s %.1lf \n", space_name[dst], space_name[src],
                 1.0 * totalMemoryTransferred[dst][src] / 1024 / 1024);
       }

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -67,17 +67,12 @@ void kokkosp_finalize_library() {
   int pid = getpid();
 
   for (int s = 0; s < num_spaces; s++) {
-    char* fileOutput      = (char*)malloc(sizeof(char) * 256);
-    char* fileOutputxfers = (char*)malloc(sizeof(char) * 256);
-
+    char* fileOutput = (char*)malloc(sizeof(char) * 256);
     snprintf(fileOutput, 256, "%s-%d-%s.memspace_usage", hostname, pid,
              space_name[s]);
 
-    snprintf(fileOutputxfers, 256, "%s-%d.memspace_transfers", hostname, pid);
-    FILE* ofile   = fopen(fileOutput, "wb");
-    FILE* ofilexf = fopen(fileOutputxfers, "wb");
+    FILE* ofile = fopen(fileOutput, "wb");
     free(fileOutput);
-    free(fileOutputxfers);
 
     fprintf(ofile, "# Space %s\n", space_name[s]);
     fprintf(ofile,
@@ -94,11 +89,9 @@ void kokkosp_finalize_library() {
     }
 
     fprintf(ofile, "# Data transferred between Kokkos Memory Spaces --- \n");
-    for (unsigned int dst = 0; (unsigned int)dst < num_spaces; dst++) {
-      for (unsigned int src = 0; (unsigned int)src < num_spaces; src++) {
-        fprintf(ofile,
-                "# Dst Mem Space     Src Mem Space    Total "
-                "Data-Transferred(MB)\n");
+    for (int dst = 0; dst < num_spaces; dst++) {
+      for (int src = 0; src < num_spaces; src++) {
+        fprintf(ofile, "# DstSpace     SrcSpace    Data-Transferred(MB)\n");
         fprintf(ofile, "%s %s %.1lf \n", space_name[dst], space_name[src],
                 1.0 * totalMemoryTransferred[dst][src] / 1024 / 1024);
       }
@@ -175,7 +168,7 @@ void kokkosp_begin_deep_copy(SpaceHandle dst_handle, const char* /* dst_name */,
   totalMemoryTransferred[space_dst][space_src] += size;
 }
 
-void kokkosp_end_deep_copy() {}
+void kokkosp_end_deep_copy() { std::lock_guard<std::mutex> lock(m); }
 
 Kokkos::Tools::Experimental::EventSet get_event_set() {
   Kokkos::Tools::Experimental::EventSet my_event_set;

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -88,10 +88,11 @@ void kokkosp_finalize_library() {
               1.0 * std::get<2>(space_size_track[s][i]) / 1024 / 1024);
     }
 
-    fprintf(ofile, "# Data transferred between Kokkos Memory Spaces --- \n");
     for (unsigned int dst = 0; dst < (unsigned int)num_spaces; dst++) {
       for (unsigned int src = 0; src < (unsigned int)num_spaces; src++) {
-        fprintf(ofile, "# DstSpace     SrcSpace    Data-Transferred(MB)\n");
+        fprintf(ofile,
+                "# Dst Mem Space     Src Mem Space    "
+                "Total-Data-Transferred(MB)\n");
         fprintf(ofile, "%s %s %.1lf \n", space_name[dst], space_name[src],
                 1.0 * totalMemoryTransferred[dst][src] / 1024 / 1024);
       }


### PR DESCRIPTION
This PR adds memory transferred between Kokkos Mem Spaces to the Kokkos Tools memory-usage tool library. This is done based on a request in Kokkos Tools Github Issue #50. 

This PR adds functionality to the tool so that the size of data transferred in the deep_copy in a Kokkos application program is accumulated during the execution of a Kokkos program. The deep_copy accumulation is done per Kokkos Memory Space dst->src pair (e.g., OpenMP on host  CUDA on device). Note that the "dst" and "src" Kokkos memory space being the same means that there was a deep_copy in the same memory space. 

When Kokkos is finalized in a Kokkos application program, the finalize callback prints out the deep_copy accumulations per memory space to the file. 