### PR TITLE
feat(roctxconnector): link `rocprofiler-sdk-roctx` as of `ROCm` 6.2

### DIFF
--- a/.github/workflows/build-with-kokkos.yml
+++ b/.github/workflows/build-with-kokkos.yml
@@ -22,7 +22,7 @@ jobs:
           - image: rocm/dev-ubuntu-22.04:5.4
             preset: ROCm
             compiler: default
-          - image: rocm/dev-ubuntu-22.04:5.7
+          - image: rocm/dev-ubuntu-22.04:6.3
             preset: ROCm
             compiler: default
     container:

--- a/profiling/roctx-connector/CMakeLists.txt
+++ b/profiling/roctx-connector/CMakeLists.txt
@@ -1,7 +1,16 @@
-find_library(ROCM_ROCTX_LIB roctx64 REQUIRED HINTS $ENV{ROCM_PATH}/lib)
-find_path(ROCM_ROCTX_INCLUDE roctx.h REQUIRED HINTS $ENV{ROCM_PATH}/include/roctracer)
-
 kp_add_library(kp_roctx_connector kp_roctx_connector.cpp)
 
-target_include_directories(kp_roctx_connector PRIVATE ${ROCM_ROCTX_INCLUDE})
-target_link_libraries(kp_roctx_connector PRIVATE ${ROCM_ROCTX_LIB})
+# As of ROCm 6.2, it is recommended to use ROCtx provided by rocprofiler-sdk-roctx
+# instead of the "old" one provided by roctracer.
+#
+# See also: https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/amd-mainline/how-to/using-rocprofv3.html
+find_package(rocprofiler-sdk-roctx CONFIG PATHS $ENV{ROCM_PATH})
+if(rocprofiler-sdk-roctx_FOUND)
+    target_link_libraries(kp_roctx_connector PRIVATE rocprofiler-sdk-roctx::rocprofiler-sdk-roctx)
+else()
+    find_library(ROCM_ROCTX_LIB roctx64 REQUIRED HINTS $ENV{ROCM_PATH}/lib)
+    find_path(ROCM_ROCTX_INCLUDE roctx.h REQUIRED HINTS $ENV{ROCM_PATH}/include/roctracer)
+
+    target_include_directories(kp_roctx_connector PRIVATE ${ROCM_ROCTX_INCLUDE})
+    target_link_libraries(kp_roctx_connector PRIVATE ${ROCM_ROCTX_LIB})
+endif()

--- a/profiling/roctx-connector/kp_roctx_connector.cpp
+++ b/profiling/roctx-connector/kp_roctx_connector.cpp
@@ -14,7 +14,11 @@
 //
 //@HEADER
 
+#if __has_include(<rocprofiler-sdk-roctx/roctx.h>)
+#include <rocprofiler-sdk-roctx/roctx.h>
+#else
 #include <roctx.h>
+#endif
 
 #include <cstdint>
 #include <iostream>


### PR DESCRIPTION
This PR updates the `CMake` logic for `roctxconnector` so as to follow AMD's recommendation to link with `rocprofiler-sdk-roctx` as of `ROCm` 6.2.

For reference, the recommendation is in the "note" on this webpage: 
- https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/amd-mainline/how-to/using-rocprofv3.html

Note that with this PR, we'll use the "new" `rocprofiler-sdk-roctx` instead of the "old" one when it is available. Another possibility would be to have an option de determine which one is linked. 