### PR TITLE
Perfetto remove redundant std::move

### DIFF
--- a/profiling/perfetto-connector/perfetto/perfetto.cc
+++ b/profiling/perfetto-connector/perfetto/perfetto.cc
@@ -72862,7 +72862,7 @@ void ProducerIPCClientImpl::OnConnect() {
 
   // If there are pending Sync() requests, send them now.
   for (const auto& pending_sync : pending_sync_reqs_)
-    Sync(std::move(pending_sync));
+    Sync(pending_sync);
   pending_sync_reqs_.clear();
 }
 

--- a/profiling/perfetto-connector/perfetto/perfetto.cc
+++ b/profiling/perfetto-connector/perfetto/perfetto.cc
@@ -72861,8 +72861,8 @@ void ProducerIPCClientImpl::OnConnect() {
                                  std::move(on_cmd));
 
   // If there are pending Sync() requests, send them now.
-  for (const auto& pending_sync : pending_sync_reqs_)
-    Sync(pending_sync);
+  for (auto& pending_sync : pending_sync_reqs_)
+    Sync(std::move(pending_sync));
   pending_sync_reqs_.clear();
 }
 


### PR DESCRIPTION
The CI complains about a redundant `std::move`, see https://github.com/kokkos/kokkos-tools/actions/runs/14736547964/job/41363971558?pr=285.