### PR TITLE
update(`nvtx-connector`): use `nvtx3`

### DIFF
--- a/.github/workflows/build-with-kokkos.yml
+++ b/.github/workflows/build-with-kokkos.yml
@@ -16,7 +16,7 @@ jobs:
           - image: nvidia/cuda:12.1.0-devel-ubuntu22.04
             preset: Cuda
             compiler: default
-          - image: nvidia/cuda:12.2.0-devel-ubuntu22.04
+          - image: nvidia/cuda:12.9.0-devel-ubuntu22.04
             preset: Cuda
             compiler: {cpp: g++-12, c: gcc-12}
           - image: rocm/dev-ubuntu-22.04:5.4

--- a/profiling/nvtx-connector/CMakeLists.txt
+++ b/profiling/nvtx-connector/CMakeLists.txt
@@ -1,4 +1,11 @@
 find_package(CUDAToolkit REQUIRED)
 kp_add_library(kp_nvtx_connector kp_nvtx_connector.cpp)
 
-target_link_libraries(kp_nvtx_connector CUDA::nvToolsExt)
+# Fallback since the imported target CUDA::nvtx3 is defined only as of CMake 3.25.
+if(NOT TARGET CUDA::nvtx3)
+    add_library(CUDA::nvtx3 INTERFACE IMPORTED)
+    target_include_directories(CUDA::nvtx3 INTERFACE "${CUDAToolkit_INCLUDE_DIRS}")
+    target_link_libraries(CUDA::nvtx3 INTERFACE ${CMAKE_DL_LIBS})
+endif()
+
+target_link_libraries(kp_nvtx_connector CUDA::nvtx3)

--- a/profiling/nvtx-connector/kp_nvtx_connector.cpp
+++ b/profiling/nvtx-connector/kp_nvtx_connector.cpp
@@ -22,7 +22,7 @@
 
 #include <pthread.h>
 
-#include "nvToolsExt.h"
+#include "nvtx3/nvToolsExt.h"
 
 #include "kp_core.hpp"
 

--- a/profiling/nvtx-focused-connector/CMakeLists.txt
+++ b/profiling/nvtx-focused-connector/CMakeLists.txt
@@ -1,4 +1,11 @@
 find_package(CUDAToolkit REQUIRED)
 kp_add_library(kp_nvtx_focused_connector kp_nvtx_focused_connector.cpp)
 
-target_link_libraries(kp_nvtx_focused_connector CUDA::nvToolsExt)
+# Fallback since the imported target CUDA::nvtx3 is defined only as of CMake 3.25.
+if(NOT TARGET CUDA::nvtx3)
+    add_library(CUDA::nvtx3 INTERFACE IMPORTED)
+    target_include_directories(CUDA::nvtx3 INTERFACE "${CUDAToolkit_INCLUDE_DIRS}")
+    target_link_libraries(CUDA::nvtx3 INTERFACE ${CMAKE_DL_LIBS})
+endif()
+
+target_link_libraries(kp_nvtx_focused_connector CUDA::nvtx3)

--- a/profiling/nvtx-focused-connector/kp_nvtx_focused_connector.cpp
+++ b/profiling/nvtx-focused-connector/kp_nvtx_focused_connector.cpp
@@ -27,7 +27,7 @@
 
 #include "kp_nvtx_focused_connector_domain.h"
 
-#include "nvToolsExt.h"
+#include "nvtx3/nvToolsExt.h"
 
 #include "kp_core.hpp"
 

--- a/profiling/nvtx-focused-connector/kp_nvtx_focused_connector_domain.h
+++ b/profiling/nvtx-focused-connector/kp_nvtx_focused_connector_domain.h
@@ -21,7 +21,7 @@
 #include <sys/time.h>
 #include <cstring>
 
-#include "nvToolsExt.h"
+#include "nvtx3/nvToolsExt.h"
 
 namespace KokkosTools {
 namespace NVTXFocusedConnector {


### PR DESCRIPTION
Nvidia has deleted `nvtx` `v2` in `CUDA` Toolkit  12.9:

- https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#id4

Following their recommendation, this PR updates the `nvtx-connector` to use `nvtx3`.

- https://github.com/NVIDIA/NVTX

Note that we have checked that `nvtx3` is available in `Docker` images dating back to at least `Cuda` 12.1.

Joint work with @romintomasetti. 