### PR TITLE
Combining multiple Kokkos Tools using a common interface (PoC)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,11 @@ if(NOT WIN32)
   add_subdirectory(profiling/perfetto-connector)
 endif()
 
+# Combined tool template
+if(NOT WIN32)
+  add_subdirectory(profiling/combined-tool-template)
+endif()
+
 # External lib connectors
 if(KokkosTools_ENABLE_PAPI)
   add_subdirectory(profiling/papi-connector)

--- a/profiling/all/kp_universal.hpp
+++ b/profiling/all/kp_universal.hpp
@@ -15,28 +15,33 @@
 //@HEADER
 
 #include <cstdint>
-#include "impl/Kokkos_Profiling_Interface.hpp"
+#include "impl/Kokkos_Profiling_C_Interface.h"
 
 #ifndef KOOKOSTOOLS_UNIVERSAL_HPP
 
 namespace KokkosTools {
-  #define GENERATE_TOOL_HEADER(TOOL_NAME) \
-  namespace TOOL_NAME { \
-    void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer, const uint32_t devInfoCount, Kokkos_Profiling_KokkosPDeviceInfo* deviceInfo); \
-    void kokkosp_finalize_library(); \
-    void kokkosp_begin_parallel_for(const char* name, const uint32_t devID, uint64_t* kID); \
-    void kokkosp_end_parallel_for(const uint64_t kID); \
-    void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID, uint64_t* kID); \
-    void kokkosp_end_parallel_reduce(const uint64_t kID); \
-    void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID, uint64_t* kID); \
-    void kokkosp_end_parallel_scan(const uint64_t kID); \
-    void kokkosp_push_profile_region(char const* regionName); \
-    void kokkosp_pop_profile_region(); \
-  } // namespace TOOL_NAME
+#define GENERATE_TOOL_HEADER(TOOL_NAME)                                      \
+  namespace TOOL_NAME {                                                      \
+  void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,  \
+                            const uint32_t devInfoCount,                     \
+                            Kokkos_Profiling_KokkosPDeviceInfo* deviceInfo); \
+  void kokkosp_finalize_library();                                           \
+  void kokkosp_begin_parallel_for(const char* name, const uint32_t devID,    \
+                                  uint64_t* kID);                            \
+  void kokkosp_end_parallel_for(const uint64_t kID);                         \
+  void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID, \
+                                     uint64_t* kID);                         \
+  void kokkosp_end_parallel_reduce(const uint64_t kID);                      \
+  void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID,   \
+                                   uint64_t* kID);                           \
+  void kokkosp_end_parallel_scan(const uint64_t kID);                        \
+  void kokkosp_push_profile_region(char const* regionName);                  \
+  void kokkosp_pop_profile_region();                                         \
+  }  // namespace TOOL_NAME
 
-  // CombinedToolTemplate examples
-  GENERATE_TOOL_HEADER(CombinedSimple)
-  GENERATE_TOOL_HEADER(CombinedDaemon)
-}
+// CombinedToolTemplate examples
+GENERATE_TOOL_HEADER(CombinedSimple)
+GENERATE_TOOL_HEADER(CombinedDaemon)
+}  // namespace KokkosTools
 
-#endif // KOOKOSTOOLS_UNIVERSAL_HPP
+#endif  // KOOKOSTOOLS_UNIVERSAL_HPP

--- a/profiling/all/kp_universal.hpp
+++ b/profiling/all/kp_universal.hpp
@@ -1,0 +1,42 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <cstdint>
+#include "impl/Kokkos_Profiling_Interface.hpp"
+
+#ifndef KOOKOSTOOLS_UNIVERSAL_HPP
+
+namespace KokkosTools {
+  #define GENERATE_TOOL_HEADER(TOOL_NAME) \
+  namespace TOOL_NAME { \
+    void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer, const uint32_t devInfoCount, Kokkos_Profiling_KokkosPDeviceInfo* deviceInfo); \
+    void kokkosp_finalize_library(); \
+    void kokkosp_begin_parallel_for(const char* name, const uint32_t devID, uint64_t* kID); \
+    void kokkosp_end_parallel_for(const uint64_t kID); \
+    void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID, uint64_t* kID); \
+    void kokkosp_end_parallel_reduce(const uint64_t kID); \
+    void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID, uint64_t* kID); \
+    void kokkosp_end_parallel_scan(const uint64_t kID); \
+    void kokkosp_push_profile_region(char const* regionName); \
+    void kokkosp_pop_profile_region(); \
+  } // namespace TOOL_NAME
+
+  // CombinedToolTemplate examples
+  GENERATE_TOOL_HEADER(CombinedSimple)
+  GENERATE_TOOL_HEADER(CombinedDaemon)
+}
+
+#endif // KOOKOSTOOLS_UNIVERSAL_HPP

--- a/profiling/combined-tool-template/CMakeLists.txt
+++ b/profiling/combined-tool-template/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_subdirectory(example-tools)
+
+# Creating the combined tool library
+kp_add_library(kp_combined_tool 
+    combined-tool-template.cpp
+)
+
+# Adding the example tools to the combined tool library
+target_link_libraries(kp_combined_tool PUBLIC kp_combined_simple kp_combined_daemon_timer)

--- a/profiling/combined-tool-template/combined-tool-guide.md
+++ b/profiling/combined-tool-template/combined-tool-guide.md
@@ -1,0 +1,101 @@
+This combined tool system allows multiple profiling tools to work together as a single profiling library. This enables:
+
+- Running multiple profiling strategies simultaneously
+- Combining complementary analysis techniques
+- Sharing a single interface with the Kokkos runtime
+
+## Daemon-Style Tools
+
+The kp_combined_daemon_timer.cpp demonstrates a background monitoring tool:
+
+### Key Components:
+
+- **Background Thread**:
+   ```cpp
+   static std::jthread s_timer_thread;
+   ```
+   Uses C++17's `std::jthread` to automatically join on destruction.
+
+- **Thread Function**:
+   ```cpp
+   void timer_thread_func(std::stop_token stop_token) {
+       while (!stop_token.stop_requested()) {
+           // Record timestamp
+           std::this_thread::sleep_for(std::chrono::milliseconds(INTERVAL_MS));
+       }
+   }
+   ```
+   Periodically collects timestamps until stopped.
+
+- **Kokkos Profiling Hooks**:
+   - `kokkosp_init_library`: Starts the background thread
+   - `kokkosp_finalize_library`: Stops the thread and outputs results
+
+## Universal Tool Interface
+
+The kp_universal.hpp provides a common interface for all tools:
+
+```cpp
+#define GENERATE_TOOL_HEADER(TOOL_NAME) \
+namespace TOOL_NAME { \
+    void kokkosp_init_library(...); \
+    void kokkosp_finalize_library(); \
+    // ... other function declarations
+}
+```
+
+This macro generates consistent function declarations for each tool, allowing the combined template to access them uniformly.
+
+## Creating a Combined Tool
+
+The combined-tool-template.cpp shows how to create a tool that delegates to multiple implementation tools:
+
+In this specific case, **Initialization/Finalization**:
+   ```cpp
+   void kokkosp_init_library(...) {
+       // Initialize all component tools
+       KokkosTools::CombinedSimple::kokkosp_init_library(...);
+       KokkosTools::CombinedDaemon::kokkosp_init_library(...);
+   }
+   ```
+
+Along with other profiling hooks, this can be used to propagate events to all included tools.
+
+## Building Combined Tools
+
+The CMake system builds the combined tool as follows:
+
+```cmake
+# Build individual tools
+add_subdirectory(example-tools)
+
+# Create combined tool
+kp_add_library(kp_combined_tool 
+    combined-tool-template.cpp
+)
+
+# Link individual tools
+target_link_libraries(kp_combined_tool PUBLIC 
+    kp_combined_simple 
+    kp_combined_daemon_timer
+)
+```
+
+## Adding a New Tool
+
+To add a new tool to the combined system:
+
+* Create your tool implementation with required profiling hooks
+* Add a namespace declaration in kp_universal.hpp
+* Add initialization and finalization calls in combined-tool-template.cpp
+* Add your tool library to `target_link_libraries` in CMakeLists.txt
+
+## Usage
+
+Load the combined tool with Kokkos by setting the appropriate environment variable:
+
+```bash
+export KOKKOS_PROFILE_LIBRARY=/path/to/libkp_combined_tool.so
+```
+
+When your application runs, all included tools will activate simultaneously.

--- a/profiling/combined-tool-template/combined-tool-template.cpp
+++ b/profiling/combined-tool-template/combined-tool-template.cpp
@@ -50,9 +50,13 @@ void kokkosp_finalize_library() {
 }
 
 void kokkosp_begin_parallel_for(const char* name, const uint32_t devID,
-                                uint64_t* kID) {}
+                                uint64_t* kID) {
+  KokkosTools::CombinedDaemon::kokkosp_begin_parallel_for(name, devID, kID); // Explicitly call the daemon tool's begin_parallel_for
+  }
 
-void kokkosp_end_parallel_for(const uint64_t kID) {}
+void kokkosp_end_parallel_for(const uint64_t kID) {
+  KokkosTools::CombinedDaemon::kokkosp_end_parallel_for(kID); // Explicitly call the daemon tool's end_parallel_for
+}
 
 void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID,
                                  uint64_t* kID) {}

--- a/profiling/combined-tool-template/combined-tool-template.cpp
+++ b/profiling/combined-tool-template/combined-tool-template.cpp
@@ -61,15 +61,16 @@ void kokkosp_end_parallel_for(const uint64_t kID) {
       kID);  // Explicitly call the daemon tool's end_parallel_for
 }
 
-void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID,
-                                 uint64_t* kID) {}
+void kokkosp_begin_parallel_scan(const char* /*name*/, const uint32_t /*devID*/,
+                                 uint64_t* /*kID*/) {}
 
-void kokkosp_end_parallel_scan(const uint64_t kID) {}
+void kokkosp_end_parallel_scan(const uint64_t /*kID*/) {}
 
-void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID,
-                                   uint64_t* kID) {}
+void kokkosp_begin_parallel_reduce(const char* /*name*/,
+                                   const uint32_t /*devID*/,
+                                   uint64_t* /*kID*/) {}
 
-void kokkosp_end_parallel_reduce(const uint64_t kID) {}
+void kokkosp_end_parallel_reduce(const uint64_t /*kID*/) {}
 
 void kokkosp_push_profile_region(char const* regionName) {
   printf("KokkosP: Entering profiling region: %s\n", regionName);  // Optional

--- a/profiling/combined-tool-template/combined-tool-template.cpp
+++ b/profiling/combined-tool-template/combined-tool-template.cpp
@@ -15,7 +15,6 @@
 //
 //@HEADER
 
-
 #include "kp_core.hpp"
 #include "kp_universal.hpp"
 #include <cstdio>
@@ -26,74 +25,71 @@ namespace CombinedToolTemplate {
 void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
                           const uint32_t devInfoCount,
                           Kokkos_Profiling_KokkosPDeviceInfo* deviceInfo) {
-    printf("-----------------------------------------------------------\n");
-    printf("KokkosP: ExampleTool (sequence is %d, version: %lu)\n",
-         loadSeq, interfaceVer);
-    printf("-----------------------------------------------------------\n"); // Optional
+  printf("-----------------------------------------------------------\n");
+  printf("KokkosP: ExampleTool (sequence is %d, version: %lu)\n", loadSeq,
+         interfaceVer);
+  printf(
+      "-----------------------------------------------------------\n");  // Optional
 
-    // Propagate initialization to the combined tools
-    KokkosTools::CombinedSimple::kokkosp_init_library(loadSeq, interfaceVer, devInfoCount, deviceInfo);
-    KokkosTools::CombinedDaemon::kokkosp_init_library(loadSeq, interfaceVer, devInfoCount, deviceInfo);
+  // Propagate initialization to the combined tools
+  KokkosTools::CombinedSimple::kokkosp_init_library(loadSeq, interfaceVer,
+                                                    devInfoCount, deviceInfo);
+  KokkosTools::CombinedDaemon::kokkosp_init_library(loadSeq, interfaceVer,
+                                                    devInfoCount, deviceInfo);
 }
 
 void kokkosp_finalize_library() {
-    printf("-----------------------------------------------------------\n");
-    printf("KokkosP: Finalization of ExampleTool. Complete.\n");
-    printf("-----------------------------------------------------------\n"); // Optional
+  printf("-----------------------------------------------------------\n");
+  printf("KokkosP: Finalization of ExampleTool. Complete.\n");
+  printf(
+      "-----------------------------------------------------------\n");  // Optional
 
-    // Propagate finalization to the combined tools
-    KokkosTools::CombinedSimple::kokkosp_finalize_library();
-    KokkosTools::CombinedDaemon::kokkosp_finalize_library();
+  // Propagate finalization to the combined tools
+  KokkosTools::CombinedSimple::kokkosp_finalize_library();
+  KokkosTools::CombinedDaemon::kokkosp_finalize_library();
 }
 
 void kokkosp_begin_parallel_for(const char* name, const uint32_t devID,
-                                uint64_t* kID) {
-}
+                                uint64_t* kID) {}
 
-void kokkosp_end_parallel_for(const uint64_t kID) {
-}
+void kokkosp_end_parallel_for(const uint64_t kID) {}
 
 void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID,
-                                 uint64_t* kID) {
-}
+                                 uint64_t* kID) {}
 
-void kokkosp_end_parallel_scan(const uint64_t kID) {
-}
+void kokkosp_end_parallel_scan(const uint64_t kID) {}
 
 void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID,
-                                   uint64_t* kID) {
-}
+                                   uint64_t* kID) {}
 
-void kokkosp_end_parallel_reduce(const uint64_t kID) {
-}
+void kokkosp_end_parallel_reduce(const uint64_t kID) {}
 
 void kokkosp_push_profile_region(char const* regionName) {
-    printf("KokkosP: Entering profiling region: %s\n", regionName); // Optional
+  printf("KokkosP: Entering profiling region: %s\n", regionName);  // Optional
 }
 
 void kokkosp_pop_profile_region() {
-    printf("KokkosP: Exiting profiling region.\n"); // Optional
+  printf("KokkosP: Exiting profiling region.\n");  // Optional
 }
 
 Kokkos::Tools::Experimental::EventSet get_event_set() {
-    Kokkos::Tools::Experimental::EventSet my_event_set;
-    memset(&my_event_set, 0,
-            sizeof(my_event_set));
-    my_event_set.init                  = kokkosp_init_library;
-    my_event_set.finalize              = kokkosp_finalize_library;
-    my_event_set.begin_parallel_for    = kokkosp_begin_parallel_for;
-    my_event_set.begin_parallel_reduce = kokkosp_begin_parallel_reduce;
-    my_event_set.begin_parallel_scan   = kokkosp_begin_parallel_scan;
-    my_event_set.end_parallel_for      = kokkosp_end_parallel_for;
-    my_event_set.end_parallel_reduce   = kokkosp_end_parallel_reduce;
-    my_event_set.end_parallel_scan     = kokkosp_end_parallel_scan;
-    my_event_set.push_region           = kokkosp_push_profile_region;
-    my_event_set.pop_region            = kokkosp_pop_profile_region;
-    return my_event_set;
+  Kokkos::Tools::Experimental::EventSet my_event_set;
+  memset(&my_event_set, 0, sizeof(my_event_set));
+  my_event_set.init                  = kokkosp_init_library;
+  my_event_set.finalize              = kokkosp_finalize_library;
+  my_event_set.begin_parallel_for    = kokkosp_begin_parallel_for;
+  my_event_set.begin_parallel_reduce = kokkosp_begin_parallel_reduce;
+  my_event_set.begin_parallel_scan   = kokkosp_begin_parallel_scan;
+  my_event_set.end_parallel_for      = kokkosp_end_parallel_for;
+  my_event_set.end_parallel_reduce   = kokkosp_end_parallel_reduce;
+  my_event_set.end_parallel_scan     = kokkosp_end_parallel_scan;
+  my_event_set.push_region           = kokkosp_push_profile_region;
+  my_event_set.pop_region            = kokkosp_pop_profile_region;
+  return my_event_set;
 }
 
-}
-}
+}  // namespace CombinedToolTemplate
+}  // namespace KokkosTools
 
 extern "C" {
 
@@ -109,5 +105,4 @@ EXPOSE_BEGIN_PARALLEL_REDUCE(impl::kokkosp_begin_parallel_reduce)
 EXPOSE_END_PARALLEL_REDUCE(impl::kokkosp_end_parallel_reduce)
 EXPOSE_PUSH_REGION(impl::kokkosp_push_profile_region)
 EXPOSE_POP_REGION(impl::kokkosp_pop_profile_region)
-
 }

--- a/profiling/combined-tool-template/combined-tool-template.cpp
+++ b/profiling/combined-tool-template/combined-tool-template.cpp
@@ -1,0 +1,113 @@
+
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+
+#include "kp_core.hpp"
+#include "kp_universal.hpp"
+#include <cstdio>
+
+namespace KokkosTools {
+namespace CombinedToolTemplate {
+
+void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
+                          const uint32_t devInfoCount,
+                          Kokkos_Profiling_KokkosPDeviceInfo* deviceInfo) {
+    printf("-----------------------------------------------------------\n");
+    printf("KokkosP: ExampleTool (sequence is %d, version: %lu)\n",
+         loadSeq, interfaceVer);
+    printf("-----------------------------------------------------------\n"); // Optional
+
+    // Propagate initialization to the combined tools
+    KokkosTools::CombinedSimple::kokkosp_init_library(loadSeq, interfaceVer, devInfoCount, deviceInfo);
+    KokkosTools::CombinedDaemon::kokkosp_init_library(loadSeq, interfaceVer, devInfoCount, deviceInfo);
+}
+
+void kokkosp_finalize_library() {
+    printf("-----------------------------------------------------------\n");
+    printf("KokkosP: Finalization of ExampleTool. Complete.\n");
+    printf("-----------------------------------------------------------\n"); // Optional
+
+    // Propagate finalization to the combined tools
+    KokkosTools::CombinedSimple::kokkosp_finalize_library();
+    KokkosTools::CombinedDaemon::kokkosp_finalize_library();
+}
+
+void kokkosp_begin_parallel_for(const char* name, const uint32_t devID,
+                                uint64_t* kID) {
+}
+
+void kokkosp_end_parallel_for(const uint64_t kID) {
+}
+
+void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID,
+                                 uint64_t* kID) {
+}
+
+void kokkosp_end_parallel_scan(const uint64_t kID) {
+}
+
+void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID,
+                                   uint64_t* kID) {
+}
+
+void kokkosp_end_parallel_reduce(const uint64_t kID) {
+}
+
+void kokkosp_push_profile_region(char const* regionName) {
+    printf("KokkosP: Entering profiling region: %s\n", regionName); // Optional
+}
+
+void kokkosp_pop_profile_region() {
+    printf("KokkosP: Exiting profiling region.\n"); // Optional
+}
+
+Kokkos::Tools::Experimental::EventSet get_event_set() {
+    Kokkos::Tools::Experimental::EventSet my_event_set;
+    memset(&my_event_set, 0,
+            sizeof(my_event_set));
+    my_event_set.init                  = kokkosp_init_library;
+    my_event_set.finalize              = kokkosp_finalize_library;
+    my_event_set.begin_parallel_for    = kokkosp_begin_parallel_for;
+    my_event_set.begin_parallel_reduce = kokkosp_begin_parallel_reduce;
+    my_event_set.begin_parallel_scan   = kokkosp_begin_parallel_scan;
+    my_event_set.end_parallel_for      = kokkosp_end_parallel_for;
+    my_event_set.end_parallel_reduce   = kokkosp_end_parallel_reduce;
+    my_event_set.end_parallel_scan     = kokkosp_end_parallel_scan;
+    my_event_set.push_region           = kokkosp_push_profile_region;
+    my_event_set.pop_region            = kokkosp_pop_profile_region;
+    return my_event_set;
+}
+
+}
+}
+
+extern "C" {
+
+namespace impl = KokkosTools::CombinedToolTemplate;
+
+EXPOSE_INIT(impl::kokkosp_init_library)
+EXPOSE_FINALIZE(impl::kokkosp_finalize_library)
+EXPOSE_BEGIN_PARALLEL_FOR(impl::kokkosp_begin_parallel_for)
+EXPOSE_END_PARALLEL_FOR(impl::kokkosp_end_parallel_for)
+EXPOSE_BEGIN_PARALLEL_SCAN(impl::kokkosp_begin_parallel_scan)
+EXPOSE_END_PARALLEL_SCAN(impl::kokkosp_end_parallel_scan)
+EXPOSE_BEGIN_PARALLEL_REDUCE(impl::kokkosp_begin_parallel_reduce)
+EXPOSE_END_PARALLEL_REDUCE(impl::kokkosp_end_parallel_reduce)
+EXPOSE_PUSH_REGION(impl::kokkosp_push_profile_region)
+EXPOSE_POP_REGION(impl::kokkosp_pop_profile_region)
+
+}

--- a/profiling/combined-tool-template/combined-tool-template.cpp
+++ b/profiling/combined-tool-template/combined-tool-template.cpp
@@ -51,11 +51,14 @@ void kokkosp_finalize_library() {
 
 void kokkosp_begin_parallel_for(const char* name, const uint32_t devID,
                                 uint64_t* kID) {
-  KokkosTools::CombinedDaemon::kokkosp_begin_parallel_for(name, devID, kID); // Explicitly call the daemon tool's begin_parallel_for
-  }
+  KokkosTools::CombinedDaemon::kokkosp_begin_parallel_for(
+      name, devID,
+      kID);  // Explicitly call the daemon tool's begin_parallel_for
+}
 
 void kokkosp_end_parallel_for(const uint64_t kID) {
-  KokkosTools::CombinedDaemon::kokkosp_end_parallel_for(kID); // Explicitly call the daemon tool's end_parallel_for
+  KokkosTools::CombinedDaemon::kokkosp_end_parallel_for(
+      kID);  // Explicitly call the daemon tool's end_parallel_for
 }
 
 void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID,

--- a/profiling/combined-tool-template/example-tools/CMakeLists.txt
+++ b/profiling/combined-tool-template/example-tools/CMakeLists.txt
@@ -1,0 +1,7 @@
+kp_add_library(kp_combined_simple
+    kp_combined_simple.cpp
+)
+
+kp_add_library(kp_combined_daemon_timer
+    kp_combined_daemon_timer.cpp
+)

--- a/profiling/combined-tool-template/example-tools/kp_combined_daemon_timer.cpp
+++ b/profiling/combined-tool-template/example-tools/kp_combined_daemon_timer.cpp
@@ -57,8 +57,8 @@ void timer_thread_func() {
 // --- Kokkos Profiling Hooks ---
 
 void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
-                          const uint32_t devInfoCount,
-                          Kokkos_Profiling_KokkosPDeviceInfo* deviceInfo) {
+                          const uint32_t /*devInfoCount*/,
+                          Kokkos_Profiling_KokkosPDeviceInfo* /*deviceInfo*/) {
   std::cout
       << "CombinedDaemon: Kokkos Profiling Library Initialized (sequence: "
       << loadSeq << ", version: " << interfaceVer << ")\n";

--- a/profiling/combined-tool-template/example-tools/kp_combined_daemon_timer.cpp
+++ b/profiling/combined-tool-template/example-tools/kp_combined_daemon_timer.cpp
@@ -1,0 +1,102 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+/*
+ * Example of a timer launched as a daemon process that can be used
+ * alongside other Kokkos profiling tools using a combined tool system.
+ */
+
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+#include <mutex>
+#include <thread>
+#include <chrono>
+
+#include "kp_core.hpp"
+#include "kp_universal.hpp"
+
+namespace KokkosTools {
+namespace CombinedDaemon {
+
+// --- Timer globals ---
+static std::vector<long long> s_timestamps;
+static std::mutex s_mutex;
+static std::jthread s_timer_thread;
+static constexpr int INTERVAL_MS = 100;
+
+void timer_thread_func(std::stop_token stop_token) {
+    while (!stop_token.stop_requested()) {
+        long long now = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+        {
+            std::lock_guard<std::mutex> lock(s_mutex);
+            s_timestamps.push_back(now);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(INTERVAL_MS));
+    }
+    std::cout << "Timer thread stopped.\n";
+}
+
+// --- Kokkos Profiling Hooks ---
+
+void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
+                          const uint32_t devInfoCount,
+                          Kokkos_Profiling_KokkosPDeviceInfo* deviceInfo) {
+    std::cout << "CombinedDaemon: Kokkos Profiling Library Initialized (sequence: "
+              << loadSeq << ", version: " << interfaceVer << ")\n";
+    s_timer_thread = std::jthread(timer_thread_func);
+}
+
+void kokkosp_finalize_library() {
+    if (s_timer_thread.joinable()) {
+        s_timer_thread.request_stop();
+    }
+    std::vector<long long> timestamps_copy;
+    {
+        std::lock_guard<std::mutex> lock(s_mutex);
+        timestamps_copy = s_timestamps;
+    }
+    std::cout << "--- TIMER_TIMESTAMP_LOG ---\n";
+    for (auto ts : timestamps_copy) {
+        std::cout << ts << '\n';
+    }
+    std::cout << "--- END ---\n";
+    std::cout << "CombinedDaemon: Kokkos Profiling Library Finalized.\n";
+}
+
+// --- Event Set Configuration ---
+
+Kokkos::Tools::Experimental::EventSet get_event_set() {
+    Kokkos::Tools::Experimental::EventSet my_event_set;
+    memset(&my_event_set, 0,
+            sizeof(my_event_set));  // zero any pointers not set here
+    my_event_set.init                  = kokkosp_init_library;
+    my_event_set.finalize              = kokkosp_finalize_library;
+    return my_event_set;
+}
+
+}  // namespace CombinedToolTemplate
+}  // namespace KokkosTools
+
+extern "C" {
+
+namespace impl = KokkosTools::CombinedDaemon;
+
+EXPOSE_INIT(impl::kokkosp_init_library)
+EXPOSE_FINALIZE(impl::kokkosp_finalize_library)
+
+}

--- a/profiling/combined-tool-template/example-tools/kp_combined_daemon_timer.cpp
+++ b/profiling/combined-tool-template/example-tools/kp_combined_daemon_timer.cpp
@@ -25,6 +25,7 @@
 #include <mutex>
 #include <thread>
 #include <chrono>
+#include <atomic>
 
 #include "kp_core.hpp"
 #include "kp_universal.hpp"
@@ -35,11 +36,12 @@ namespace CombinedDaemon {
 // --- Timer globals ---
 static std::vector<long long> s_timestamps;
 static std::mutex s_mutex;
-static std::jthread s_timer_thread;
+static std::thread s_timer_thread;
+static std::atomic<bool> s_timer_stop_flag{false};
 static constexpr int INTERVAL_MS = 100;
 
-void timer_thread_func(std::stop_token stop_token) {
-    while (!stop_token.stop_requested()) {
+void timer_thread_func() {
+    while (!s_timer_stop_flag.load(std::memory_order_relaxed)) {
         long long now = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::system_clock::now().time_since_epoch()).count();
         {
@@ -48,7 +50,7 @@ void timer_thread_func(std::stop_token stop_token) {
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(INTERVAL_MS));
     }
-    std::cout << "Timer thread stopped.\n";
+    // std::cout << "Timer thread stopped.\n";
 }
 
 // --- Kokkos Profiling Hooks ---
@@ -58,12 +60,14 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
                           Kokkos_Profiling_KokkosPDeviceInfo* deviceInfo) {
     std::cout << "CombinedDaemon: Kokkos Profiling Library Initialized (sequence: "
               << loadSeq << ", version: " << interfaceVer << ")\n";
-    s_timer_thread = std::jthread(timer_thread_func);
+    s_timer_stop_flag = false;
+    s_timer_thread = std::thread(timer_thread_func);
 }
 
 void kokkosp_finalize_library() {
     if (s_timer_thread.joinable()) {
-        s_timer_thread.request_stop();
+        s_timer_stop_flag = true;
+        s_timer_thread.join();
     }
     std::vector<long long> timestamps_copy;
     {

--- a/profiling/combined-tool-template/example-tools/kp_combined_daemon_timer.cpp
+++ b/profiling/combined-tool-template/example-tools/kp_combined_daemon_timer.cpp
@@ -41,16 +41,17 @@ static std::atomic<bool> s_timer_stop_flag{false};
 static constexpr int INTERVAL_MS = 100;
 
 void timer_thread_func() {
-    while (!s_timer_stop_flag.load(std::memory_order_relaxed)) {
-        long long now = std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::system_clock::now().time_since_epoch()).count();
-        {
-            std::lock_guard<std::mutex> lock(s_mutex);
-            s_timestamps.push_back(now);
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(INTERVAL_MS));
+  while (!s_timer_stop_flag.load(std::memory_order_relaxed)) {
+    long long now = std::chrono::duration_cast<std::chrono::milliseconds>(
+                        std::chrono::system_clock::now().time_since_epoch())
+                        .count();
+    {
+      std::lock_guard<std::mutex> lock(s_mutex);
+      s_timestamps.push_back(now);
     }
-    // std::cout << "Timer thread stopped.\n";
+    std::this_thread::sleep_for(std::chrono::milliseconds(INTERVAL_MS));
+  }
+  // std::cout << "Timer thread stopped.\n";
 }
 
 // --- Kokkos Profiling Hooks ---
@@ -58,42 +59,43 @@ void timer_thread_func() {
 void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
                           const uint32_t devInfoCount,
                           Kokkos_Profiling_KokkosPDeviceInfo* deviceInfo) {
-    std::cout << "CombinedDaemon: Kokkos Profiling Library Initialized (sequence: "
-              << loadSeq << ", version: " << interfaceVer << ")\n";
-    s_timer_stop_flag = false;
-    s_timer_thread = std::thread(timer_thread_func);
+  std::cout
+      << "CombinedDaemon: Kokkos Profiling Library Initialized (sequence: "
+      << loadSeq << ", version: " << interfaceVer << ")\n";
+  s_timer_stop_flag = false;
+  s_timer_thread    = std::thread(timer_thread_func);
 }
 
 void kokkosp_finalize_library() {
-    if (s_timer_thread.joinable()) {
-        s_timer_stop_flag = true;
-        s_timer_thread.join();
-    }
-    std::vector<long long> timestamps_copy;
-    {
-        std::lock_guard<std::mutex> lock(s_mutex);
-        timestamps_copy = s_timestamps;
-    }
-    std::cout << "--- TIMER_TIMESTAMP_LOG ---\n";
-    for (auto ts : timestamps_copy) {
-        std::cout << ts << '\n';
-    }
-    std::cout << "--- END ---\n";
-    std::cout << "CombinedDaemon: Kokkos Profiling Library Finalized.\n";
+  if (s_timer_thread.joinable()) {
+    s_timer_stop_flag = true;
+    s_timer_thread.join();
+  }
+  std::vector<long long> timestamps_copy;
+  {
+    std::lock_guard<std::mutex> lock(s_mutex);
+    timestamps_copy = s_timestamps;
+  }
+  std::cout << "--- TIMER_TIMESTAMP_LOG ---\n";
+  for (auto ts : timestamps_copy) {
+    std::cout << ts << '\n';
+  }
+  std::cout << "--- END ---\n";
+  std::cout << "CombinedDaemon: Kokkos Profiling Library Finalized.\n";
 }
 
 // --- Event Set Configuration ---
 
 Kokkos::Tools::Experimental::EventSet get_event_set() {
-    Kokkos::Tools::Experimental::EventSet my_event_set;
-    memset(&my_event_set, 0,
-            sizeof(my_event_set));  // zero any pointers not set here
-    my_event_set.init                  = kokkosp_init_library;
-    my_event_set.finalize              = kokkosp_finalize_library;
-    return my_event_set;
+  Kokkos::Tools::Experimental::EventSet my_event_set;
+  memset(&my_event_set, 0,
+         sizeof(my_event_set));  // zero any pointers not set here
+  my_event_set.init     = kokkosp_init_library;
+  my_event_set.finalize = kokkosp_finalize_library;
+  return my_event_set;
 }
 
-}  // namespace CombinedToolTemplate
+}  // namespace CombinedDaemon
 }  // namespace KokkosTools
 
 extern "C" {
@@ -102,5 +104,4 @@ namespace impl = KokkosTools::CombinedDaemon;
 
 EXPOSE_INIT(impl::kokkosp_init_library)
 EXPOSE_FINALIZE(impl::kokkosp_finalize_library)
-
 }

--- a/profiling/combined-tool-template/example-tools/kp_combined_daemon_timer.cpp
+++ b/profiling/combined-tool-template/example-tools/kp_combined_daemon_timer.cpp
@@ -84,6 +84,15 @@ void kokkosp_finalize_library() {
   std::cout << "CombinedDaemon: Kokkos Profiling Library Finalized.\n";
 }
 
+void kokkosp_begin_parallel_for(const char* name, const uint32_t /*devID*/,
+                                uint64_t* /*kID*/) {
+  std::cout << "CombinedDaemon: Beginning parallel for: " << name << '\n';
+}
+
+void kokkosp_end_parallel_for(const uint64_t /*kID*/) {
+  std::cout << "CombinedDaemon: Ending parallel for.\n";
+}
+
 // --- Event Set Configuration ---
 
 Kokkos::Tools::Experimental::EventSet get_event_set() {
@@ -92,6 +101,10 @@ Kokkos::Tools::Experimental::EventSet get_event_set() {
          sizeof(my_event_set));  // zero any pointers not set here
   my_event_set.init     = kokkosp_init_library;
   my_event_set.finalize = kokkosp_finalize_library;
+    my_event_set.begin_parallel_for =
+        kokkosp_begin_parallel_for;
+    my_event_set.end_parallel_for =
+        kokkosp_end_parallel_for;
   return my_event_set;
 }
 
@@ -104,4 +117,6 @@ namespace impl = KokkosTools::CombinedDaemon;
 
 EXPOSE_INIT(impl::kokkosp_init_library)
 EXPOSE_FINALIZE(impl::kokkosp_finalize_library)
+EXPOSE_BEGIN_PARALLEL_FOR(impl::kokkosp_begin_parallel_for)
+EXPOSE_END_PARALLEL_FOR(impl::kokkosp_end_parallel_for)
 }

--- a/profiling/combined-tool-template/example-tools/kp_combined_daemon_timer.cpp
+++ b/profiling/combined-tool-template/example-tools/kp_combined_daemon_timer.cpp
@@ -99,12 +99,10 @@ Kokkos::Tools::Experimental::EventSet get_event_set() {
   Kokkos::Tools::Experimental::EventSet my_event_set;
   memset(&my_event_set, 0,
          sizeof(my_event_set));  // zero any pointers not set here
-  my_event_set.init     = kokkosp_init_library;
-  my_event_set.finalize = kokkosp_finalize_library;
-    my_event_set.begin_parallel_for =
-        kokkosp_begin_parallel_for;
-    my_event_set.end_parallel_for =
-        kokkosp_end_parallel_for;
+  my_event_set.init               = kokkosp_init_library;
+  my_event_set.finalize           = kokkosp_finalize_library;
+  my_event_set.begin_parallel_for = kokkosp_begin_parallel_for;
+  my_event_set.end_parallel_for   = kokkosp_end_parallel_for;
   return my_event_set;
 }
 

--- a/profiling/combined-tool-template/example-tools/kp_combined_simple.cpp
+++ b/profiling/combined-tool-template/example-tools/kp_combined_simple.cpp
@@ -26,8 +26,8 @@ namespace CombinedSimple {
 // --- Kokkos Profiling Hooks ---
 
 void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
-                          const uint32_t devInfoCount,
-                          Kokkos_Profiling_KokkosPDeviceInfo* deviceInfo) {
+                          const uint32_t /*devInfoCount*/,
+                          Kokkos_Profiling_KokkosPDeviceInfo* /*deviceInfo*/) {
   std::cout
       << "CombinedSimple: Kokkos Profiling Library Initialized (sequence: "
       << loadSeq << ", version: " << interfaceVer << ")\n";

--- a/profiling/combined-tool-template/example-tools/kp_combined_simple.cpp
+++ b/profiling/combined-tool-template/example-tools/kp_combined_simple.cpp
@@ -1,0 +1,60 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <cstdlib>
+#include <iostream>
+
+#include "kp_core.hpp"
+#include "kp_universal.hpp"
+
+namespace KokkosTools {
+namespace CombinedSimple {
+
+// --- Kokkos Profiling Hooks ---
+
+void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
+                          const uint32_t devInfoCount,
+                          Kokkos_Profiling_KokkosPDeviceInfo* deviceInfo) {
+    std::cout << "CombinedSimple: Kokkos Profiling Library Initialized (sequence: "
+              << loadSeq << ", version: " << interfaceVer << ")\n";
+}
+
+void kokkosp_finalize_library() {
+    std::cout << "CombinedSimple: Kokkos Profiling Library Finalized.\n";
+}
+
+// --- Event Set Configuration ---
+
+Kokkos::Tools::Experimental::EventSet get_event_set() {
+    Kokkos::Tools::Experimental::EventSet my_event_set;
+    memset(&my_event_set, 0,
+            sizeof(my_event_set));  // zero any pointers not set here
+    my_event_set.init                  = kokkosp_init_library;
+    my_event_set.finalize              = kokkosp_finalize_library;
+    return my_event_set;
+}
+
+}  // namespace CombinedToolTemplate
+}  // namespace KokkosTools
+
+extern "C" {
+
+namespace impl = KokkosTools::CombinedSimple;
+
+EXPOSE_INIT(impl::kokkosp_init_library)
+EXPOSE_FINALIZE(impl::kokkosp_finalize_library)
+
+}

--- a/profiling/combined-tool-template/example-tools/kp_combined_simple.cpp
+++ b/profiling/combined-tool-template/example-tools/kp_combined_simple.cpp
@@ -28,26 +28,27 @@ namespace CombinedSimple {
 void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
                           const uint32_t devInfoCount,
                           Kokkos_Profiling_KokkosPDeviceInfo* deviceInfo) {
-    std::cout << "CombinedSimple: Kokkos Profiling Library Initialized (sequence: "
-              << loadSeq << ", version: " << interfaceVer << ")\n";
+  std::cout
+      << "CombinedSimple: Kokkos Profiling Library Initialized (sequence: "
+      << loadSeq << ", version: " << interfaceVer << ")\n";
 }
 
 void kokkosp_finalize_library() {
-    std::cout << "CombinedSimple: Kokkos Profiling Library Finalized.\n";
+  std::cout << "CombinedSimple: Kokkos Profiling Library Finalized.\n";
 }
 
 // --- Event Set Configuration ---
 
 Kokkos::Tools::Experimental::EventSet get_event_set() {
-    Kokkos::Tools::Experimental::EventSet my_event_set;
-    memset(&my_event_set, 0,
-            sizeof(my_event_set));  // zero any pointers not set here
-    my_event_set.init                  = kokkosp_init_library;
-    my_event_set.finalize              = kokkosp_finalize_library;
-    return my_event_set;
+  Kokkos::Tools::Experimental::EventSet my_event_set;
+  memset(&my_event_set, 0,
+         sizeof(my_event_set));  // zero any pointers not set here
+  my_event_set.init     = kokkosp_init_library;
+  my_event_set.finalize = kokkosp_finalize_library;
+  return my_event_set;
 }
 
-}  // namespace CombinedToolTemplate
+}  // namespace CombinedSimple
 }  // namespace KokkosTools
 
 extern "C" {
@@ -56,5 +57,4 @@ namespace impl = KokkosTools::CombinedSimple;
 
 EXPOSE_INIT(impl::kokkosp_init_library)
 EXPOSE_FINALIZE(impl::kokkosp_finalize_library)
-
 }


### PR DESCRIPTION
This (draft for now) Pull Request presents a proof-of-concept that might enhance the flexibility of Kokkos Tools by enabling the simultaneous use of multiple profiling and debugging utilities at once. This PR introduces a combined tool template that would allow for multiple tools to function and communicate at once.

Key features of this proposal include:

* A unified interface for integrating and managing multiple Kokkos Tools within a single shared library.
* Comprehensive CMake configurations to streamline the build process for this combined approach.
* Illustrative example tools, `CombinedSimple` and `CombinedDaemon`, showcasing how this architecture allows profiling hooks to be effectively dispatched to different embedded tools. For instance, `CombinedDaemon` is an example of a tool evolving as a separate thread, capable of measuring data at regular time intervals while continuously listening for hook notifications. In this specific example, it merely logs timestamps, but it demonstrates the potential for regular data collection, a method that warrants further investigation.

This capability unlocks advanced analysis scenarios by allowing users to leverage a richer set of tools concurrently.

**Note (outdated) :** `CombinedDaemon` is not using `jthread` anymore, so it doesn't need C++20.