### PR TITLE
Update ci c++20

### DIFF
--- a/.github/workflows/build-with-kokkos.yml
+++ b/.github/workflows/build-with-kokkos.yml
@@ -13,13 +13,13 @@ jobs:
           - image: ubuntu:22.04
             preset: OpenMP
             compiler: default
-          - image: nvidia/cuda:12.1.0-devel-ubuntu22.04
+          - image: nvidia/cuda:12.2.0-devel-ubuntu22.04
             preset: Cuda
             compiler: default
           - image: nvidia/cuda:12.2.0-devel-ubuntu22.04
             preset: Cuda
             compiler: {cpp: g++-12, c: gcc-12}
-          - image: rocm/dev-ubuntu-22.04:5.4
+          - image: rocm/dev-ubuntu-22.04:6.3
             preset: ROCm
             compiler: default
           - image: rocm/dev-ubuntu-22.04:6.3

--- a/kokkos.presets.json
+++ b/kokkos.presets.json
@@ -6,7 +6,7 @@
             "binaryDir"     : "${sourceDir}/build-with-${presetName}",
             "cacheVariables" : {
                 "CMAKE_BUILD_TYPE"              : "Release",
-                "CMAKE_CXX_STANDARD"            : "17",
+                "CMAKE_CXX_STANDARD"            : "20",
                 "CMAKE_CXX_EXTENSIONS"          : "OFF",
                 "BUILD_SHARED_LIBS"             : "ON"
             }


### PR DESCRIPTION
Proposes to use c++20 since we require it in Kokkos and the CI here uses the latest develop. Not sure if we want to keep it that way