### PR TITLE
Ci downgrade rocm to 6.2

### DIFF
--- a/.github/workflows/build-with-kokkos.yml
+++ b/.github/workflows/build-with-kokkos.yml
@@ -22,7 +22,7 @@ jobs:
           - image: rocm/dev-ubuntu-22.04:6.3
             preset: ROCm
             compiler: default
-          - image: rocm/dev-ubuntu-22.04:6.3
+          - image: rocm/dev-ubuntu-22.04:6.2
             preset: ROCm
             compiler: default
     container:


### PR DESCRIPTION
as per recommendation of @Rombur, as response to https://github.com/kokkos/kokkos-tools/pull/303#discussion_r2311040309