### PR TITLE
Bug: Add header cstdint to kp_shared.h

### DIFF
--- a/profiling/simple-kernel-timer/kp_shared.h
+++ b/profiling/simple-kernel-timer/kp_shared.h
@@ -17,6 +17,7 @@
 #ifndef _H_KOKKOSP_KERNEL_SHARED
 #define _H_KOKKOSP_KERNEL_SHARED
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <vector>


### PR DESCRIPTION
### Description
Compiling kokkos-tools using g++-15 resulted in the error
```
kokkos-tools/profiling/simple-kernel-timer/kp_shared.h:28:8: error: ‘uint64_t’ does not name a type
   28 | extern uint64_t uniqID;
      |        ^~~~~~~~
```
Adding the header `#include <cstdint>` to kp_shared.h solves the issue.

### Toolchain
OS: OpenSuse Tumbleweed
Compiler: g++ (SUSE Linux) 15.2.1 20251006