### PR TITLE
Make simple kernel timer stdout in ascii text

### DIFF
--- a/profiling/simple-kernel-timer/kp_kernel_info.h
+++ b/profiling/simple-kernel-timer/kp_kernel_info.h
@@ -33,7 +33,6 @@ class KernelPerformanceInfo {
       : kernelName(std::move(kName)), kType(kernelType) {}
 
   KernelExecutionType getKernelType() const { return kType; }
-  void setKernelType(KernelExecutionType kernelType) { kType = kernelType; }
 
   void incrementCount() { callCount++; }
 

--- a/profiling/simple-kernel-timer/kp_kernel_info.h
+++ b/profiling/simple-kernel-timer/kp_kernel_info.h
@@ -33,6 +33,7 @@ class KernelPerformanceInfo {
       : kernelName(std::move(kName)), kType(kernelType) {}
 
   KernelExecutionType getKernelType() const { return kType; }
+  void setKernelType(KernelExecutionType kernelType) { kType = kernelType; }
 
   void incrementCount() { callCount++; }
 

--- a/profiling/simple-kernel-timer/kp_kernel_timer.cpp
+++ b/profiling/simple-kernel-timer/kp_kernel_timer.cpp
@@ -12,135 +12,75 @@
 
 namespace KokkosTools {
 namespace KernelTimer {
-enum KokkosToolsTimerOutputFormat { ascii, binary, json };
-
 void print_ascii(std::map<std::string, KernelPerformanceInfo*>& count_map,
                  double totalExecuteTime) {
   std::vector<KernelPerformanceInfo*> kernelInfo;
   double totalKernelsTime    = 0;
   uint64_t totalKernelsCalls = 0;
 
-  for (auto kernel_itr = count_map.begin(); kernel_itr != count_map.end();
-       kernel_itr++) {
-    KernelPerformanceInfo* new_kernel =
-        new KernelPerformanceInfo(kernel_itr->first, PARALLEL_FOR);
-    new_kernel->setKernelType(kernel_itr->second->getKernelType());
-    new_kernel->addTime(kernel_itr->second->getTime());
-    new_kernel->addCallCount(kernel_itr->second->getCallCount());
-    int kernelIndex = find_index(kernelInfo, kernel_itr->first);
-    if (kernelIndex > -1) {
-      kernelInfo[kernelIndex]->addTime(new_kernel->getTime());
-      kernelInfo[kernelIndex]->addCallCount(new_kernel->getCallCount());
-    } else {
-      kernelInfo.push_back(new_kernel);
-    }
-
-    delete new_kernel;
+  for (auto const& [name, info] : count_map) {
+    kernelInfo.push_back(info);
   }
 
   std::sort(kernelInfo.begin(), kernelInfo.end(), compareKernelPerformanceInfo);
 
-  for (unsigned int i = 0; i < kernelInfo.size(); i++) {
-    if (kernelInfo[i]->getKernelType() != REGION) {
-      totalKernelsTime += kernelInfo[i]->getTime();
-      totalKernelsCalls += kernelInfo[i]->getCallCount();
+  // Calculate total time in kernels and total calls to kernels for summary
+  for (auto const& info : kernelInfo) {
+    if (info->getKernelType() != REGION) {
+      totalKernelsTime += info->getTime();
+      totalKernelsCalls += info->getCallCount();
     }
   }
 
+  // Header matching kp_reader.cpp
   printf(
-      " (Type)   Total Time, Call Count, Avg. Time per Call, %%Total Time in "
+      "\n (Type)   Total Time, Call Count, Avg. Time per Call, %%Total Time in "
       "Kernels, %%Total Program Time\n");
   printf(
       "------------------------------------------------------------------------"
       "-\n\n");
 
+  char delimiter = ' ';
+  // We check for the environment delimiter if set during init
+  if (outputDelimiter != nullptr && strlen(outputDelimiter) > 0) {
+    delimiter = outputDelimiter[0];
+  }
+
+  auto print_row = [&](KernelPerformanceInfo* info) {
+    const double callCountDouble = (double)info->getCallCount();
+    const char* typeStr          = " (Region)  ";
+    switch (info->getKernelType()) {
+      case PARALLEL_FOR: typeStr = " (ParFor)  "; break;
+      case PARALLEL_REDUCE: typeStr = " (ParRed)  "; break;
+      case PARALLEL_SCAN: typeStr = " (ParScan) "; break;
+      default: break;
+    }
+
+    printf(
+        "- %s\n%s%c%f%c%" PRIu64 "%c%f%c%f%c%f\n", info->getName().c_str(),
+        typeStr, delimiter, info->getTime(), delimiter, info->getCallCount(),
+        delimiter, info->getTime() / std::max(1.0, callCountDouble), delimiter,
+        (info->getTime() / std::max(1e-9, totalKernelsTime)) * 100.0, delimiter,
+        (info->getTime() / std::max(1e-9, totalExecuteTime)) * 100.0);
+  };
+
   printf("Regions: \n\n");
-  char delimiter  = ' ';
-  int fixed_width = 0;
-  for (unsigned int i = 0; i < kernelInfo.size(); i++) {
-    const double callCountDouble = (double)kernelInfo[i]->getCallCount();
-
-    if (kernelInfo[i]->getKernelType() != REGION) continue;
-    if (fixed_width)
-      printf("- %100s\n%11s%c%15.5f%c%12" PRIu64 "%c%15.5f%c%7.3f%c%7.3f\n",
-             kernelInfo[i]->getName().c_str(),
-             (kernelInfo[i]->getKernelType() == PARALLEL_FOR)
-                 ? (" (ParFor)  ")
-                 : ((kernelInfo[i]->getKernelType() == PARALLEL_REDUCE)
-                        ? (" (ParRed)  ")
-                        : ((kernelInfo[i]->getKernelType() == PARALLEL_SCAN)
-                               ? (" (ParScan) ")
-                               : (" (Region)  "))),
-             delimiter, kernelInfo[i]->getTime(), delimiter,
-             kernelInfo[i]->getCallCount(), delimiter,
-             kernelInfo[i]->getTime() / callCountDouble, delimiter,
-             (kernelInfo[i]->getTime() / totalKernelsTime) * 100.0, delimiter,
-             (kernelInfo[i]->getTime() / totalExecuteTime) * 100.0);
-    else
-      printf("- %s\n%s%c%f%c%" PRIu64 "%c%f%c%f%c%f\n",
-             kernelInfo[i]->getName().c_str(),
-             (kernelInfo[i]->getKernelType() == PARALLEL_FOR)
-                 ? (" (ParFor)  ")
-                 : ((kernelInfo[i]->getKernelType() == PARALLEL_REDUCE)
-                        ? (" (ParRed)  ")
-                        : ((kernelInfo[i]->getKernelType() == PARALLEL_SCAN)
-                               ? (" (ParScan) ")
-                               : (" (REGION)  "))),
-             delimiter, kernelInfo[i]->getTime(), delimiter,
-             kernelInfo[i]->getCallCount(), delimiter,
-             kernelInfo[i]->getTime() / callCountDouble, delimiter,
-             (kernelInfo[i]->getTime() / totalKernelsTime) * 100.0, delimiter,
-             (kernelInfo[i]->getTime() / totalExecuteTime) * 100.0);
+  for (auto const& info : kernelInfo) {
+    if (info->getKernelType() == REGION) print_row(info);
   }
 
-  printf("\n");
   printf(
-      "------------------------------------------------------------------------"
-      "-\n");
+      "\n----------------------------------------------------------------------"
+      "---\n");
   printf("Kernels: \n\n");
-
-  for (unsigned int i = 0; i < kernelInfo.size(); i++) {
-    const double callCountDouble = (double)kernelInfo[i]->getCallCount();
-
-    if (kernelInfo[i]->getKernelType() == REGION) continue;
-    if (fixed_width)
-      printf("- %100s\n%11s%c%15.5f%c%12" PRIu64 "%c%15.5f%c%7.3f%c%7.3f\n",
-             kernelInfo[i]->getName().c_str(),
-             (kernelInfo[i]->getKernelType() == PARALLEL_FOR)
-                 ? (" (ParFor)  ")
-                 : ((kernelInfo[i]->getKernelType() == PARALLEL_REDUCE)
-                        ? (" (ParRed)  ")
-                        : ((kernelInfo[i]->getKernelType() == PARALLEL_SCAN)
-                               ? (" (ParScan) ")
-                               : (" (Region)  "))),
-             delimiter, kernelInfo[i]->getTime(), delimiter,
-             kernelInfo[i]->getCallCount(), delimiter,
-             kernelInfo[i]->getTime() / callCountDouble, delimiter,
-             (kernelInfo[i]->getTime() / totalKernelsTime) * 100.0, delimiter,
-             (kernelInfo[i]->getTime() / totalExecuteTime) * 100.0);
-    else
-      printf("- %s\n%s%c%f%c%" PRIu64 "%c%f%c%f%c%f\n",
-             kernelInfo[i]->getName().c_str(),
-             (kernelInfo[i]->getKernelType() == PARALLEL_FOR)
-                 ? (" (ParFor)  ")
-                 : ((kernelInfo[i]->getKernelType() == PARALLEL_REDUCE)
-                        ? (" (ParRed)  ")
-                        : ((kernelInfo[i]->getKernelType() == PARALLEL_SCAN)
-                               ? (" (ParScan) ")
-                               : (" (REGION)  "))),
-             delimiter, kernelInfo[i]->getTime(), delimiter,
-             kernelInfo[i]->getCallCount(), delimiter,
-             kernelInfo[i]->getTime() / callCountDouble, delimiter,
-             (kernelInfo[i]->getTime() / totalKernelsTime) * 100.0, delimiter,
-             (kernelInfo[i]->getTime() / totalExecuteTime) * 100.0);
+  for (auto const& info : kernelInfo) {
+    if (info->getKernelType() != REGION) print_row(info);
   }
 
-  printf("\n");
   printf(
-      "------------------------------------------------------------------------"
-      "-\n");
-  printf("Summary:\n");
-  printf("\n");
+      "\n----------------------------------------------------------------------"
+      "---\n");
+  printf("Summary:\n\n");
   printf(
       "Total Execution Time (incl. Kokkos + non-Kokkos):      %20.5f seconds\n",
       totalExecuteTime);
@@ -151,14 +91,13 @@ void print_ascii(std::map<std::string, KernelPerformanceInfo*>& count_map,
       "   -> Time outside Kokkos kernels:                     %20.5f seconds\n",
       (totalExecuteTime - totalKernelsTime));
   printf("   -> Percentage in Kokkos kernels:                    %20.2f %%\n",
-         (totalKernelsTime / totalExecuteTime) * 100);
+         (totalKernelsTime / std::max(1e-9, totalExecuteTime)) * 100.0);
   printf("Total Calls to Kokkos Kernels:                         %20" PRIu64
          "\n",
          totalKernelsCalls);
-  printf("\n");
   printf(
       "------------------------------------------------------------------------"
-      "-\n");
+      "-\n\n");
 }
 
 bool is_region(KernelPerformanceInfo const& kp) {
@@ -190,7 +129,8 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
 }
 
 void kokkosp_finalize_library() {
-  double finishTime = seconds();
+  double finishTime             = seconds();
+  const double totalExecuteTime = (finishTime - initTime);
 
   auto is_enabled = [](const char* env_var) {
     const char* env_var_raw = getenv(env_var);
@@ -203,16 +143,8 @@ void kokkosp_finalize_library() {
   const bool kokkos_tools_timer_binary =
       is_enabled("KOKKOS_TOOLS_TIMER_BINARY");
 
-  KokkosToolsTimerOutputFormat output_format = ascii;
-  std::string output_format_str              = "txt";
-  const double totalExecuteTime              = (finishTime - initTime);
-  if (kokkos_tools_timer_json) {
-    output_format     = json;
-    output_format_str = "json";
-  } else if (kokkos_tools_timer_binary) {
-    output_format     = binary;
-    output_format_str = "dat";
-  } else {
+  // Quick return for ascii output (default)
+  if (!kokkos_tools_timer_json && !kokkos_tools_timer_binary) {
     print_ascii(count_map, totalExecuteTime);
     return;
   }
@@ -224,79 +156,73 @@ void kokkosp_finalize_library() {
 
   char* fileOutput = (char*)malloc(sizeof(char) * 256);
   snprintf(fileOutput, 256, "%s-%d.%s", hostname, (int)getpid(),
-           output_format_str.c_str());
+           kokkos_tools_timer_json ? "json" : "dat");
 
   free(hostname);
   FILE* output_data = fopen(fileOutput, "wb");
-  switch (output_format) {
-    case binary: {
-      fwrite(&totalExecuteTime, sizeof(totalExecuteTime), 1, output_data);
+  if (kokkos_tools_timer_binary) {
+    fwrite(&totalExecuteTime, sizeof(totalExecuteTime), 1, output_data);
 
-      for (auto kernel_itr = count_map.begin(); kernel_itr != count_map.end();
-           kernel_itr++) {
-        kernel_itr->second->writeToBinaryFile(output_data);
-      }
-      break;
+    for (auto kernel_itr = count_map.begin(); kernel_itr != count_map.end();
+         kernel_itr++) {
+      kernel_itr->second->writeToBinaryFile(output_data);
     }
-    case json: {
-      std::vector<KernelPerformanceInfo*> kernelList;
+  } else if (kokkos_tools_timer_json) {
+    std::vector<KernelPerformanceInfo*> kernelList;
 
-      for (auto kernel_itr = count_map.begin(); kernel_itr != count_map.end();
-           kernel_itr++) {
-        kernelList.push_back(kernel_itr->second);
-        kernelTimes += kernel_itr->second->getTime();
-      }
+    for (auto kernel_itr = count_map.begin(); kernel_itr != count_map.end();
+         kernel_itr++) {
+      kernelList.push_back(kernel_itr->second);
+      kernelTimes += kernel_itr->second->getTime();
+    }
 
-      std::sort(kernelList.begin(), kernelList.end(),
-                compareKernelPerformanceInfo);
+    std::sort(kernelList.begin(), kernelList.end(),
+              compareKernelPerformanceInfo);
 
-      fprintf(output_data, "{\n\"kokkos-kernel-data\" : {\n");
-      fprintf(output_data, "    \"total-app-time\"         : %10.3f,\n",
-              totalExecuteTime);
-      fprintf(output_data, "    \"total-kernel-times\"     : %10.3f,\n",
-              kernelTimes);
-      fprintf(output_data, "    \"total-non-kernel-times\" : %10.3f,\n",
-              (totalExecuteTime - kernelTimes));
+    fprintf(output_data, "{\n\"kokkos-kernel-data\" : {\n");
+    fprintf(output_data, "    \"total-app-time\"         : %10.3f,\n",
+            totalExecuteTime);
+    fprintf(output_data, "    \"total-kernel-times\"     : %10.3f,\n",
+            kernelTimes);
+    fprintf(output_data, "    \"total-non-kernel-times\" : %10.3f,\n",
+            (totalExecuteTime - kernelTimes));
 
-      const double percentKokkos = (kernelTimes / totalExecuteTime) * 100.0;
-      fprintf(output_data, "    \"percent-in-kernels\"     : %6.2f,\n",
-              percentKokkos);
-      fprintf(output_data, "    \"unique-kernel-calls\"    : %22llu,\n",
-              (unsigned long long)count_map.size());
-      fprintf(output_data, "\n");
+    const double percentKokkos = (kernelTimes / totalExecuteTime) * 100.0;
+    fprintf(output_data, "    \"percent-in-kernels\"     : %6.2f,\n",
+            percentKokkos);
+    fprintf(output_data, "    \"unique-kernel-calls\"    : %22llu,\n",
+            (unsigned long long)count_map.size());
+    fprintf(output_data, "\n");
 
-      fprintf(output_data, "    \"region-perf-info\"       : [\n");
+    fprintf(output_data, "    \"region-perf-info\"       : [\n");
 
 #define KERNEL_INFO_INDENT "       "
 
-      bool print_comma = false;
-      for (auto const& kernel : count_map) {
-        if (!is_region(*std::get<1>(kernel))) continue;
-        if (print_comma) fprintf(output_data, ",\n");
-        kernel.second->writeToJSONFile(output_data, KERNEL_INFO_INDENT);
-        print_comma = true;
-      }
-
-      fprintf(output_data, "\n");
-      fprintf(output_data, "    ],\n");
-
-      fprintf(output_data, "    \"kernel-perf-info\"       : [\n");
-
-      print_comma = false;
-      for (auto const& kernel : count_map) {
-        if (is_region(*std::get<1>(kernel))) continue;
-        if (print_comma) fprintf(output_data, ",\n");
-        kernel.second->writeToJSONFile(output_data, KERNEL_INFO_INDENT);
-        print_comma = true;
-      }
-
-      fprintf(output_data, "\n");
-      fprintf(output_data, "    ]\n");
-
-      fprintf(output_data, "}\n}");
-      break;
+    bool print_comma = false;
+    for (auto const& kernel : count_map) {
+      if (!is_region(*std::get<1>(kernel))) continue;
+      if (print_comma) fprintf(output_data, ",\n");
+      kernel.second->writeToJSONFile(output_data, KERNEL_INFO_INDENT);
+      print_comma = true;
     }
-    default: fprintf(stderr, "Error: Unrecognized output format\n"); break;
+
+    fprintf(output_data, "\n");
+    fprintf(output_data, "    ],\n");
+
+    fprintf(output_data, "    \"kernel-perf-info\"       : [\n");
+
+    print_comma = false;
+    for (auto const& kernel : count_map) {
+      if (is_region(*std::get<1>(kernel))) continue;
+      if (print_comma) fprintf(output_data, ",\n");
+      kernel.second->writeToJSONFile(output_data, KERNEL_INFO_INDENT);
+      print_comma = true;
+    }
+
+    fprintf(output_data, "\n");
+    fprintf(output_data, "    ]\n");
+
+    fprintf(output_data, "}\n}");
   }
 
   fclose(output_data);

--- a/profiling/simple-kernel-timer/kp_kernel_timer.cpp
+++ b/profiling/simple-kernel-timer/kp_kernel_timer.cpp
@@ -12,6 +12,155 @@
 
 namespace KokkosTools {
 namespace KernelTimer {
+enum KokkosToolsTimerOutputFormat { ascii, binary, json };
+
+void print_ascii(FILE* output,
+                 std::map<std::string, KernelPerformanceInfo*>& count_map,
+                 double totalExecuteTime) {
+  std::vector<KernelPerformanceInfo*> kernelInfo;
+  double totalKernelsTime    = 0;
+  uint64_t totalKernelsCalls = 0;
+
+  for (auto kernel_itr = count_map.begin(); kernel_itr != count_map.end();
+       kernel_itr++) {
+    KernelPerformanceInfo* new_kernel =
+        new KernelPerformanceInfo(kernel_itr->first, PARALLEL_FOR);
+    new_kernel->setKernelType(kernel_itr->second->getKernelType());
+    new_kernel->addTime(kernel_itr->second->getTime());
+    new_kernel->addCallCount(kernel_itr->second->getCallCount());
+    int kernelIndex = find_index(kernelInfo, kernel_itr->first);
+    if (kernelIndex > -1) {
+      kernelInfo[kernelIndex]->addTime(new_kernel->getTime());
+      kernelInfo[kernelIndex]->addCallCount(new_kernel->getCallCount());
+    } else {
+      kernelInfo.push_back(new_kernel);
+    }
+
+    delete new_kernel;
+  }
+
+  std::sort(kernelInfo.begin(), kernelInfo.end(), compareKernelPerformanceInfo);
+
+  for (unsigned int i = 0; i < kernelInfo.size(); i++) {
+    if (kernelInfo[i]->getKernelType() != REGION) {
+      totalKernelsTime += kernelInfo[i]->getTime();
+      totalKernelsCalls += kernelInfo[i]->getCallCount();
+    }
+  }
+
+  printf(
+      " (Type)   Total Time, Call Count, Avg. Time per Call, %%Total Time in "
+      "Kernels, %%Total Program Time\n");
+  printf(
+      "------------------------------------------------------------------------"
+      "-\n\n");
+
+  printf("Regions: \n\n");
+  char delimiter  = ' ';
+  int fixed_width = 0;
+  for (unsigned int i = 0; i < kernelInfo.size(); i++) {
+    const double callCountDouble = (double)kernelInfo[i]->getCallCount();
+
+    if (kernelInfo[i]->getKernelType() != REGION) continue;
+    if (fixed_width)
+      printf("- %100s\n%11s%c%15.5f%c%12" PRIu64 "%c%15.5f%c%7.3f%c%7.3f\n",
+             kernelInfo[i]->getName().c_str(),
+             (kernelInfo[i]->getKernelType() == PARALLEL_FOR)
+                 ? (" (ParFor)  ")
+                 : ((kernelInfo[i]->getKernelType() == PARALLEL_REDUCE)
+                        ? (" (ParRed)  ")
+                        : ((kernelInfo[i]->getKernelType() == PARALLEL_SCAN)
+                               ? (" (ParScan) ")
+                               : (" (Region)  "))),
+             delimiter, kernelInfo[i]->getTime(), delimiter,
+             kernelInfo[i]->getCallCount(), delimiter,
+             kernelInfo[i]->getTime() / callCountDouble, delimiter,
+             (kernelInfo[i]->getTime() / totalKernelsTime) * 100.0, delimiter,
+             (kernelInfo[i]->getTime() / totalExecuteTime) * 100.0);
+    else
+      printf("- %s\n%s%c%f%c%" PRIu64 "%c%f%c%f%c%f\n",
+             kernelInfo[i]->getName().c_str(),
+             (kernelInfo[i]->getKernelType() == PARALLEL_FOR)
+                 ? (" (ParFor)  ")
+                 : ((kernelInfo[i]->getKernelType() == PARALLEL_REDUCE)
+                        ? (" (ParRed)  ")
+                        : ((kernelInfo[i]->getKernelType() == PARALLEL_SCAN)
+                               ? (" (ParScan) ")
+                               : (" (REGION)  "))),
+             delimiter, kernelInfo[i]->getTime(), delimiter,
+             kernelInfo[i]->getCallCount(), delimiter,
+             kernelInfo[i]->getTime() / callCountDouble, delimiter,
+             (kernelInfo[i]->getTime() / totalKernelsTime) * 100.0, delimiter,
+             (kernelInfo[i]->getTime() / totalExecuteTime) * 100.0);
+  }
+
+  printf("\n");
+  printf(
+      "------------------------------------------------------------------------"
+      "-\n");
+  printf("Kernels: \n\n");
+
+  for (unsigned int i = 0; i < kernelInfo.size(); i++) {
+    const double callCountDouble = (double)kernelInfo[i]->getCallCount();
+
+    if (kernelInfo[i]->getKernelType() == REGION) continue;
+    if (fixed_width)
+      printf("- %100s\n%11s%c%15.5f%c%12" PRIu64 "%c%15.5f%c%7.3f%c%7.3f\n",
+             kernelInfo[i]->getName().c_str(),
+             (kernelInfo[i]->getKernelType() == PARALLEL_FOR)
+                 ? (" (ParFor)  ")
+                 : ((kernelInfo[i]->getKernelType() == PARALLEL_REDUCE)
+                        ? (" (ParRed)  ")
+                        : ((kernelInfo[i]->getKernelType() == PARALLEL_SCAN)
+                               ? (" (ParScan) ")
+                               : (" (Region)  "))),
+             delimiter, kernelInfo[i]->getTime(), delimiter,
+             kernelInfo[i]->getCallCount(), delimiter,
+             kernelInfo[i]->getTime() / callCountDouble, delimiter,
+             (kernelInfo[i]->getTime() / totalKernelsTime) * 100.0, delimiter,
+             (kernelInfo[i]->getTime() / totalExecuteTime) * 100.0);
+    else
+      printf("- %s\n%s%c%f%c%" PRIu64 "%c%f%c%f%c%f\n",
+             kernelInfo[i]->getName().c_str(),
+             (kernelInfo[i]->getKernelType() == PARALLEL_FOR)
+                 ? (" (ParFor)  ")
+                 : ((kernelInfo[i]->getKernelType() == PARALLEL_REDUCE)
+                        ? (" (ParRed)  ")
+                        : ((kernelInfo[i]->getKernelType() == PARALLEL_SCAN)
+                               ? (" (ParScan) ")
+                               : (" (REGION)  "))),
+             delimiter, kernelInfo[i]->getTime(), delimiter,
+             kernelInfo[i]->getCallCount(), delimiter,
+             kernelInfo[i]->getTime() / callCountDouble, delimiter,
+             (kernelInfo[i]->getTime() / totalKernelsTime) * 100.0, delimiter,
+             (kernelInfo[i]->getTime() / totalExecuteTime) * 100.0);
+  }
+
+  printf("\n");
+  printf(
+      "------------------------------------------------------------------------"
+      "-\n");
+  printf("Summary:\n");
+  printf("\n");
+  printf(
+      "Total Execution Time (incl. Kokkos + non-Kokkos):      %20.5f seconds\n",
+      totalExecuteTime);
+  printf(
+      "Total Time in Kokkos kernels:                          %20.5f seconds\n",
+      totalKernelsTime);
+  printf(
+      "   -> Time outside Kokkos kernels:                     %20.5f seconds\n",
+      (totalExecuteTime - totalKernelsTime));
+  printf("   -> Percentage in Kokkos kernels:                    %20.2f %%\n",
+         (totalKernelsTime / totalExecuteTime) * 100);
+  printf("Total Calls to Kokkos Kernels:                         %20" PRIu64
+         "\n",
+         totalKernelsCalls);
+  printf("\n");
+  printf(
+      "------------------------------------------------------------------------"
+      "-\n");
+}
 
 bool is_region(KernelPerformanceInfo const& kp) {
   return kp.getKernelType() == REGION;
@@ -44,13 +193,26 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
 void kokkosp_finalize_library() {
   double finishTime = seconds();
 
-  const char* kokkos_tools_timer_json_raw = getenv("KOKKOS_TOOLS_TIMER_JSON");
-  const bool kokkos_tools_timer_json =
-      kokkos_tools_timer_json_raw == NULL
-          ? false
-          : strcmp(kokkos_tools_timer_json_raw, "1") == 0 ||
-                strcmp(kokkos_tools_timer_json_raw, "true") == 0 ||
-                strcmp(kokkos_tools_timer_json_raw, "True") == 0;
+  auto is_enabled = [](const char* env_var) {
+    const char* env_var_raw = getenv(env_var);
+    return env_var_raw != nullptr &&
+           (strcmp(env_var_raw, "1") == 0 || strcmp(env_var_raw, "true") == 0 ||
+            strcmp(env_var_raw, "True") == 0);
+  };
+
+  const bool kokkos_tools_timer_json = is_enabled("KOKKOS_TOOLS_TIMER_JSON");
+  const bool kokkos_tools_timer_binary =
+      is_enabled("KOKKOS_TOOLS_TIMER_BINARY");
+
+  KokkosToolsTimerOutputFormat output_format = ascii;
+  std::string output_format_str              = "txt";
+  if (kokkos_tools_timer_json) {
+    output_format     = json;
+    output_format_str = "json";
+  } else if (kokkos_tools_timer_binary) {
+    output_format     = binary;
+    output_format_str = "dat";
+  }
 
   double kernelTimes = 0;
 
@@ -59,75 +221,84 @@ void kokkosp_finalize_library() {
 
   char* fileOutput = (char*)malloc(sizeof(char) * 256);
   snprintf(fileOutput, 256, "%s-%d.%s", hostname, (int)getpid(),
-           kokkos_tools_timer_json ? "json" : "dat");
+           output_format_str.c_str());
 
   free(hostname);
-  FILE* output_data = fopen(fileOutput, "wb");
-
+  FILE* output_data             = fopen(fileOutput, "wb");
   const double totalExecuteTime = (finishTime - initTime);
-  if (!kokkos_tools_timer_json) {
-    fwrite(&totalExecuteTime, sizeof(totalExecuteTime), 1, output_data);
-
-    for (auto kernel_itr = count_map.begin(); kernel_itr != count_map.end();
-         kernel_itr++) {
-      kernel_itr->second->writeToBinaryFile(output_data);
+  switch (output_format) {
+    case ascii: {
+      print_ascii(output_data, count_map, totalExecuteTime);
+      break;
     }
-  } else {
-    std::vector<KernelPerformanceInfo*> kernelList;
+    case binary: {
+      fwrite(&totalExecuteTime, sizeof(totalExecuteTime), 1, output_data);
 
-    for (auto kernel_itr = count_map.begin(); kernel_itr != count_map.end();
-         kernel_itr++) {
-      kernelList.push_back(kernel_itr->second);
-      kernelTimes += kernel_itr->second->getTime();
+      for (auto kernel_itr = count_map.begin(); kernel_itr != count_map.end();
+           kernel_itr++) {
+        kernel_itr->second->writeToBinaryFile(output_data);
+      }
+      break;
     }
+    case json: {
+      std::vector<KernelPerformanceInfo*> kernelList;
 
-    std::sort(kernelList.begin(), kernelList.end(),
-              compareKernelPerformanceInfo);
+      for (auto kernel_itr = count_map.begin(); kernel_itr != count_map.end();
+           kernel_itr++) {
+        kernelList.push_back(kernel_itr->second);
+        kernelTimes += kernel_itr->second->getTime();
+      }
 
-    fprintf(output_data, "{\n\"kokkos-kernel-data\" : {\n");
-    fprintf(output_data, "    \"total-app-time\"         : %10.3f,\n",
-            totalExecuteTime);
-    fprintf(output_data, "    \"total-kernel-times\"     : %10.3f,\n",
-            kernelTimes);
-    fprintf(output_data, "    \"total-non-kernel-times\" : %10.3f,\n",
-            (totalExecuteTime - kernelTimes));
+      std::sort(kernelList.begin(), kernelList.end(),
+                compareKernelPerformanceInfo);
 
-    const double percentKokkos = (kernelTimes / totalExecuteTime) * 100.0;
-    fprintf(output_data, "    \"percent-in-kernels\"     : %6.2f,\n",
-            percentKokkos);
-    fprintf(output_data, "    \"unique-kernel-calls\"    : %22llu,\n",
-            (unsigned long long)count_map.size());
-    fprintf(output_data, "\n");
+      fprintf(output_data, "{\n\"kokkos-kernel-data\" : {\n");
+      fprintf(output_data, "    \"total-app-time\"         : %10.3f,\n",
+              totalExecuteTime);
+      fprintf(output_data, "    \"total-kernel-times\"     : %10.3f,\n",
+              kernelTimes);
+      fprintf(output_data, "    \"total-non-kernel-times\" : %10.3f,\n",
+              (totalExecuteTime - kernelTimes));
 
-    fprintf(output_data, "    \"region-perf-info\"       : [\n");
+      const double percentKokkos = (kernelTimes / totalExecuteTime) * 100.0;
+      fprintf(output_data, "    \"percent-in-kernels\"     : %6.2f,\n",
+              percentKokkos);
+      fprintf(output_data, "    \"unique-kernel-calls\"    : %22llu,\n",
+              (unsigned long long)count_map.size());
+      fprintf(output_data, "\n");
+
+      fprintf(output_data, "    \"region-perf-info\"       : [\n");
 
 #define KERNEL_INFO_INDENT "       "
 
-    bool print_comma = false;
-    for (auto const& kernel : count_map) {
-      if (!is_region(*std::get<1>(kernel))) continue;
-      if (print_comma) fprintf(output_data, ",\n");
-      kernel.second->writeToJSONFile(output_data, KERNEL_INFO_INDENT);
-      print_comma = true;
+      bool print_comma = false;
+      for (auto const& kernel : count_map) {
+        if (!is_region(*std::get<1>(kernel))) continue;
+        if (print_comma) fprintf(output_data, ",\n");
+        kernel.second->writeToJSONFile(output_data, KERNEL_INFO_INDENT);
+        print_comma = true;
+      }
+
+      fprintf(output_data, "\n");
+      fprintf(output_data, "    ],\n");
+
+      fprintf(output_data, "    \"kernel-perf-info\"       : [\n");
+
+      print_comma = false;
+      for (auto const& kernel : count_map) {
+        if (is_region(*std::get<1>(kernel))) continue;
+        if (print_comma) fprintf(output_data, ",\n");
+        kernel.second->writeToJSONFile(output_data, KERNEL_INFO_INDENT);
+        print_comma = true;
+      }
+
+      fprintf(output_data, "\n");
+      fprintf(output_data, "    ]\n");
+
+      fprintf(output_data, "}\n}");
+      break;
     }
-
-    fprintf(output_data, "\n");
-    fprintf(output_data, "    ],\n");
-
-    fprintf(output_data, "    \"kernel-perf-info\"       : [\n");
-
-    print_comma = false;
-    for (auto const& kernel : count_map) {
-      if (is_region(*std::get<1>(kernel))) continue;
-      if (print_comma) fprintf(output_data, ",\n");
-      kernel.second->writeToJSONFile(output_data, KERNEL_INFO_INDENT);
-      print_comma = true;
-    }
-
-    fprintf(output_data, "\n");
-    fprintf(output_data, "    ]\n");
-
-    fprintf(output_data, "}\n}");
+    default: fprintf(stderr, "Error: Unrecognized output format\n"); break;
   }
 
   fclose(output_data);

--- a/profiling/simple-kernel-timer/kp_kernel_timer.cpp
+++ b/profiling/simple-kernel-timer/kp_kernel_timer.cpp
@@ -205,6 +205,7 @@ void kokkosp_finalize_library() {
 
   KokkosToolsTimerOutputFormat output_format = ascii;
   std::string output_format_str              = "txt";
+  const double totalExecuteTime              = (finishTime - initTime);
   if (kokkos_tools_timer_json) {
     output_format     = json;
     output_format_str = "json";
@@ -226,12 +227,8 @@ void kokkosp_finalize_library() {
            output_format_str.c_str());
 
   free(hostname);
-  FILE* output_data             = fopen(fileOutput, "wb");
-  const double totalExecuteTime = (finishTime - initTime);
+  FILE* output_data = fopen(fileOutput, "wb");
   switch (output_format) {
-    case ascii: {
-      break;
-    }
     case binary: {
       fwrite(&totalExecuteTime, sizeof(totalExecuteTime), 1, output_data);
 

--- a/profiling/simple-kernel-timer/kp_kernel_timer.cpp
+++ b/profiling/simple-kernel-timer/kp_kernel_timer.cpp
@@ -14,8 +14,7 @@ namespace KokkosTools {
 namespace KernelTimer {
 enum KokkosToolsTimerOutputFormat { ascii, binary, json };
 
-void print_ascii(FILE* output,
-                 std::map<std::string, KernelPerformanceInfo*>& count_map,
+void print_ascii(std::map<std::string, KernelPerformanceInfo*>& count_map,
                  double totalExecuteTime) {
   std::vector<KernelPerformanceInfo*> kernelInfo;
   double totalKernelsTime    = 0;
@@ -212,6 +211,9 @@ void kokkosp_finalize_library() {
   } else if (kokkos_tools_timer_binary) {
     output_format     = binary;
     output_format_str = "dat";
+  } else {
+    print_ascii(count_map, totalExecuteTime);
+    return;
   }
 
   double kernelTimes = 0;
@@ -228,7 +230,6 @@ void kokkosp_finalize_library() {
   const double totalExecuteTime = (finishTime - initTime);
   switch (output_format) {
     case ascii: {
-      print_ascii(output_data, count_map, totalExecuteTime);
       break;
     }
     case binary: {


### PR DESCRIPTION
This PR aims at making the default output of simple kernel timer into stdout in ascii.

For the original behavior, you need to set `KOKKOS_TOOLS_TIMER_BINARY = true`.


Simple example

```
KokkosP: Simple Kernel Timer Library Initialized (sequence is 0, version: 20240906)
Elapsed time: 0.156063 [s]

 (Type)   Total Time, Call Count, Avg. Time per Call, %Total Time in Kernels, %Total Program Time
-------------------------------------------------------------------------

Regions: 

- KokkosFFT::create_plan[TPL_cufft]
 (Region)   2.499047 2 1.249524 2531.790119 93.934408
- KokkosFFT::exec_plan[TPL_cufftExecZ2D]
 (Region)   0.023082 2002 0.000012 23.384202 0.867600
- KokkosFFT::exec_plan[TPL_cufftExecD2Z]
 (Region)   0.011615 1001 0.000012 11.767462 0.436596
- KokkosFFT::cleanup_plan[TPL_cufft]
 (Region)   0.000078 2 0.000039 0.078984 0.002930

-------------------------------------------------------------------------
Kernels: 

- advect_x
 (ParFor)   0.043851 2000 0.000022 44.425443 1.648272
- advect_v
 (ParFor)   0.019495 1000 0.000019 19.750921 0.732798
- compute_rho
 (ParFor)   0.013256 1001 0.000013 13.429516 0.498262
- solve_poisson
 (ParFor)   0.010916 1001 0.000011 11.059018 0.410311
- poisson
 (ParFor)   0.010211 1001 0.000010 10.345261 0.383830
- Kokkos::View::initialization [rho_k]
 (ParFor)   0.000715 1 0.000715 0.724386 0.026876
- init_fn
 (ParFor)   0.000056 1 0.000056 0.056762 0.002106
- Kokkos::View::initialization [f0] via memset
 (ParFor)   0.000029 3 0.000010 0.029468 0.001093
- Kokkos::View::initialization [rho] via memset
 (ParFor)   0.000028 3 0.000009 0.028502 0.001057
- Kokkos::View::initialization [linspace] via memset
 (ParFor)   0.000027 2 0.000014 0.027536 0.001022
- Kokkos::View::initialization [phi] via memset
 (ParFor)   0.000027 3 0.000009 0.027536 0.001022
- Kokkos::View::initialization [fn] via memset
 (ParFor)   0.000025 2 0.000013 0.025603 0.000950
- Kokkos::View::initialization [f] via memset
 (ParFor)   0.000013 1 0.000013 0.013285 0.000493
- Kokkos::View::initialization [phi_k]
 (ParFor)   0.000012 1 0.000012 0.012077 0.000448
- Kokkos::View::initialization [E_k]
 (ParFor)   0.000011 1 0.000011 0.011111 0.000412
- Kokkos::View::initialization [E] via memset
 (ParFor)   0.000009 1 0.000009 0.009179 0.000341
- Kokkos::View::initialization [delta_rho] via memset
 (ParFor)   0.000009 1 0.000009 0.009179 0.000341
- Kokkos::View::initialization [inv_kx] via memset
 (ParFor)   0.000008 1 0.000008 0.007971 0.000296
- Kokkos::View::initialization [linspace_mirror] via memset
 (ParFor)   0.000004 2 0.000002 0.004106 0.000152
- Kokkos::View::initialization [inv_kx_mirror] via memset
 (ParFor)   0.000002 1 0.000002 0.001932 0.000072
- Kokkos::View::initialization [freq] via memset
 (ParFor)   0.000001 1 0.000001 0.001208 0.000045

-------------------------------------------------------------------------
Summary:

Total Execution Time (incl. Kokkos + non-Kokkos):                   2.66042 seconds
Total Time in Kokkos kernels:                                       0.09871 seconds
   -> Time outside Kokkos kernels:                                  2.56171 seconds
   -> Percentage in Kokkos kernels:                                    3.71 %
Total Calls to Kokkos Kernels:                                         6028
-------------------------------------------------------------------------
```
