### PR TITLE
Build with werror

### DIFF
--- a/.github/workflows/build-with-kokkos.yml
+++ b/.github/workflows/build-with-kokkos.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Build Kokkos Tools, enabling examples
         run: |
           cmake -S . --preset=${{ matrix.preset }}
-          cmake --build --preset=${{ matrix.preset }} --verbose
+          cmake --build --preset=${{ matrix.preset }}
           cmake --install build-with-${{ matrix.preset }} --prefix=/opt/kokkos-tools
       # For now, GitHub runners are used. These runner don't have GPUs. Therefore, testing can only be done for OpenMP.
       # Skip variorum test since the architecture detected by variorum is not supported

--- a/.github/workflows/build-with-kokkos.yml
+++ b/.github/workflows/build-with-kokkos.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Build Kokkos Tools, enabling examples
         run: |
           cmake -S . --preset=${{ matrix.preset }}
-          cmake --build --preset=${{ matrix.preset }}
+          cmake --build --preset=${{ matrix.preset }} --verbose
           cmake --install build-with-${{ matrix.preset }} --prefix=/opt/kokkos-tools
       # For now, GitHub runners are used. These runner don't have GPUs. Therefore, testing can only be done for OpenMP.
       # Skip variorum test since the architecture detected by variorum is not supported

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -24,7 +24,7 @@
       "inherits": "default",
       "cacheVariables": {
         "CMAKE_CXX_COMPILER": "$env{Kokkos_ROOT}/bin/nvcc_wrapper",
-        "CMAKE_CXX_FLAGS": "$penv{CMAKE_CXX_FLAGS} -Wno-undef"
+        "CMAKE_CXX_FLAGS": "-Werror -Wno-undef"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -24,7 +24,7 @@
       "inherits": "default",
       "cacheVariables": {
         "CMAKE_CXX_COMPILER": "$env{Kokkos_ROOT}/bin/nvcc_wrapper",
-        "CMAKE_CXX_FLAGS": "-Werror -Wno-undef"
+        "CMAKE_CXX_FLAGS": "-Werror"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,6 +7,7 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_CXX_STANDARD": "17",
+        "CMAKE_CXX_FLAGS": "-Werror",
         "KokkosTools_ENABLE_EXAMPLES": "ON",
         "KokkosTools_ENABLE_SINGLE": "ON",
         "KokkosTools_ENABLE_MPI": "ON",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -42,20 +42,17 @@
     {
       "name": "OpenMP",
       "configurePreset": "OpenMP",
-      "inheritConfigureEnvironment": true,
-      "verbose": true
+      "inheritConfigureEnvironment": true
     },
     {
       "name": "Cuda",
       "configurePreset": "Cuda",
-      "inheritConfigureEnvironment": true,
-      "verbose": true
+      "inheritConfigureEnvironment": true
     },
     {
       "name": "ROCm",
       "configurePreset": "ROCm",
-      "inheritConfigureEnvironment": true,
-      "verbose": true
+      "inheritConfigureEnvironment": true
     }
   ],
   "testPresets": [

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -42,17 +42,20 @@
     {
       "name": "OpenMP",
       "configurePreset": "OpenMP",
-      "inheritConfigureEnvironment": true
+      "inheritConfigureEnvironment": true,
+      "verbose": true
     },
     {
       "name": "Cuda",
       "configurePreset": "Cuda",
-      "inheritConfigureEnvironment": true
+      "inheritConfigureEnvironment": true,
+      "verbose": true
     },
     {
       "name": "ROCm",
       "configurePreset": "ROCm",
-      "inheritConfigureEnvironment": true
+      "inheritConfigureEnvironment": true,
+      "verbose": true
     }
   ],
   "testPresets": [

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -23,7 +23,8 @@
       "name": "Cuda",
       "inherits": "default",
       "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "$env{Kokkos_ROOT}/bin/nvcc_wrapper"
+        "CMAKE_CXX_COMPILER": "$env{Kokkos_ROOT}/bin/nvcc_wrapper",
+        "CMAKE_CXX_FLAGS": "$penv{CMAKE_CXX_FLAGS} -Wno-undef"
       }
     },
     {

--- a/cmake/BuildGTest.cmake
+++ b/cmake/BuildGTest.cmake
@@ -32,4 +32,5 @@ if (NOT googletest_POPULATED)
     set(INSTALL_GTEST OFF)
 
     add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
+    set_target_properties(gtest PROPERTIES COMPILE_OPTIONS -w)
 endif()

--- a/cmake/BuildGTest.cmake
+++ b/cmake/BuildGTest.cmake
@@ -33,4 +33,5 @@ if (NOT googletest_POPULATED)
 
     add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
     set_target_properties(gtest PROPERTIES COMPILE_OPTIONS -w)
+    set_target_properties(gmock PROPERTIES COMPILE_OPTIONS -w)
 endif()

--- a/common/kernel-filter/kp_kernel_filter.cpp
+++ b/common/kernel-filter/kp_kernel_filter.cpp
@@ -119,7 +119,9 @@ extern "C" void kokkosp_init_library(const int loadSeq,
         printf("KokkosP: KOKKOS_TOOLS_LIBS not set.\n");
         profileLibrary = getenv("KOKKOS_PROFILE_LIBRARY");
         if (NULL == profileLibrary) {
-          printf("KokkosP: No library to call in %s\n", profileLibrary);
+          printf(
+              "KokkosP: No library to call. Neither KOKKOS_TOOLS_LIBS nor "
+              "KOKKOS_PROFILE_LIBRARY is set.\n");
           exit(-1);
         } else {
           printf(

--- a/profiling/memory-events/kp_memory_events.cpp
+++ b/profiling/memory-events/kp_memory_events.cpp
@@ -59,43 +59,43 @@ void kokkosp_finalize_library() {
 
   int pid = getpid();
 
+  // ---- Memory event log ----
   std::string fileOutput = hostname + "-" + std::to_string(pid) + ".mem_events";
-
   std::ofstream ofile(fileOutput, std::ios::binary);
 
   ofile << "# Memory Events\n";
-  ofile << "# Time     Ptr                  Size        MemSpace      Op"
-        << "         Name\n";
+  ofile << "# Time     Ptr                  Size        MemSpace      Op       "
+           "  Name\n";
 
   for (const auto& e : events) {
-    e.print_record(ofile);  // assuming you overload to accept std::ostream
+    e.print_record(ofile);
   }
 
-  ofile.close();
+  // ---- Per memory space usage ----
+  for (int s = 0; s < num_spaces; ++s) {
+    std::string fileName = hostname + "-" + std::to_string(pid) + "-" +
+                           space_name[s] + ".memspace_usage";
 
-  for (int s = 0; s < num_spaces; s++) {
-    char* fileOutput = (char*)malloc(sizeof(char) * 256);
-    [[maybe_unused]] auto written_bytes =
-        snprintf(fileOutput, 256, "%s-%d-%s.memspace_usage", hostname.c_str(),
-                 pid, space_name[s]);
+    std::ofstream spaceFile(fileName, std::ios::binary);
 
-    FILE* ofile = fopen(fileOutput, "wb");
-    free(fileOutput);
+    spaceFile << "# Space " << space_name[s] << "\n";
+    spaceFile
+        << "# Time(s)  Size(MB)   HighWater(MB)   HighWater-Process(MB)\n";
 
-    fprintf(ofile, "# Space %s\n", space_name[s]);
-    fprintf(ofile,
-            "# Time(s)  Size(MB)   HighWater(MB)   HighWater-Process(MB)\n");
     uint64_t maxvalue = 0;
-    for (unsigned int i = 0; i < space_size_track[s].size(); i++) {
-      if (std::get<1>(space_size_track[s][i]) > maxvalue)
-        maxvalue = std::get<1>(space_size_track[s][i]);
-      fprintf(ofile, "%lf %.1lf %.1lf %.1lf\n",
-              std::get<0>(space_size_track[s][i]),
-              1.0 * std::get<1>(space_size_track[s][i]) / 1024 / 1024,
-              1.0 * maxvalue / 1024 / 1024,
-              1.0 * std::get<2>(space_size_track[s][i]) / 1024 / 1024);
+
+    for (const auto& entry : space_size_track[s]) {
+      double time         = std::get<0>(entry);
+      uint64_t size       = std::get<1>(entry);
+      uint64_t process_hw = std::get<2>(entry);
+
+      if (size > maxvalue) maxvalue = size;
+
+      spaceFile << time << " " << std::fixed << std::setprecision(1)
+                << (size / 1024.0 / 1024.0) << " "
+                << (maxvalue / 1024.0 / 1024.0) << " "
+                << (process_hw / 1024.0 / 1024.0) << "\n";
     }
-    fclose(ofile);
   }
 }
 

--- a/profiling/memory-events/kp_memory_events.cpp
+++ b/profiling/memory-events/kp_memory_events.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#include <array>
 #include <cstdio>
 #include <cinttypes>
 #include <vector>
@@ -15,8 +14,6 @@
 #include "kp_core.hpp"
 #include "kp_memory_events.hpp"
 #include "kp_timer.hpp"
-
-#include <fstream>
 
 namespace KokkosTools {
 namespace MemoryEvents {
@@ -53,50 +50,47 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
 }
 
 void kokkosp_finalize_library() {
-  std::array<char, 256> hostname_buf{};
-  gethostname(hostname_buf.data(), hostname_buf.size());
-  std::string hostname(hostname_buf.data());
-
+  char* hostname = (char*)malloc(sizeof(char) * 256);
+  gethostname(hostname, 256);
   int pid = getpid();
+  std::string hostname_string;
 
-  // ---- Memory event log ----
-  std::string fileOutput = hostname + "-" + std::to_string(pid) + ".mem_events";
-  std::ofstream ofile(fileOutput, std::ios::binary);
+  {
+    std::string fileOutput =
+        hostname_string + "-" + std::to_string(pid) + ".mem_events";
+    FILE* ofile = fopen(fileOutput.c_str(), "wb");
 
-  ofile << "# Memory Events\n";
-  ofile << "# Time     Ptr                  Size        MemSpace      Op       "
-           "  Name\n";
-
-  for (const auto& e : events) {
-    e.print_record(ofile);
+    fprintf(ofile, "# Memory Events\n");
+    fprintf(ofile,
+            "# Time     Ptr                  Size        MemSpace      Op      "
+            "   Name\n");
+    for (unsigned int i = 0; i < events.size(); i++)
+      events[i].print_record(ofile);
+    fclose(ofile);
   }
 
-  // ---- Per memory space usage ----
   for (int s = 0; s < num_spaces; ++s) {
-    std::string fileName = hostname + "-" + std::to_string(pid) + "-" +
-                           space_name[s] + ".memspace_usage";
+    std::string fileOutput = hostname_string + "-" + std::to_string(pid) + "-" +
+                             space_name[s] + ".memspace_usage";
 
-    std::ofstream spaceFile(fileName, std::ios::binary);
+    FILE* ofile = fopen(fileOutput.c_str(), "wb");
 
-    spaceFile << "# Space " << space_name[s] << "\n";
-    spaceFile
-        << "# Time(s)  Size(MB)   HighWater(MB)   HighWater-Process(MB)\n";
-
+    fprintf(ofile, "# Space %s\n", space_name[s]);
+    fprintf(ofile,
+            "# Time(s)  Size(MB)   HighWater(MB)   HighWater-Process(MB)\n");
     uint64_t maxvalue = 0;
-
-    for (const auto& entry : space_size_track[s]) {
-      double time         = std::get<0>(entry);
-      uint64_t size       = std::get<1>(entry);
-      uint64_t process_hw = std::get<2>(entry);
-
-      if (size > maxvalue) maxvalue = size;
-
-      spaceFile << time << " " << std::fixed << std::setprecision(1)
-                << (size / 1024.0 / 1024.0) << " "
-                << (maxvalue / 1024.0 / 1024.0) << " "
-                << (process_hw / 1024.0 / 1024.0) << "\n";
+    for (unsigned int i = 0; i < space_size_track[s].size(); i++) {
+      if (std::get<1>(space_size_track[s][i]) > maxvalue)
+        maxvalue = std::get<1>(space_size_track[s][i]);
+      fprintf(ofile, "%lf %.1lf %.1lf %.1lf\n",
+              std::get<0>(space_size_track[s][i]),
+              1.0 * std::get<1>(space_size_track[s][i]) / 1024 / 1024,
+              1.0 * maxvalue / 1024 / 1024,
+              1.0 * std::get<2>(space_size_track[s][i]) / 1024 / 1024);
     }
+    fclose(ofile);
   }
+  free(hostname);
 }
 
 void kokkosp_allocate_data(const SpaceHandle space, const char* label,

--- a/profiling/memory-events/kp_memory_events.cpp
+++ b/profiling/memory-events/kp_memory_events.cpp
@@ -52,8 +52,8 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
 void kokkosp_finalize_library() {
   char* hostname = (char*)malloc(sizeof(char) * 256);
   gethostname(hostname, 256);
-  int pid = getpid();
-  std::string hostname_string;
+  int pid                     = getpid();
+  std::string hostname_string = hostname;
 
   {
     std::string fileOutput =

--- a/profiling/memory-events/kp_memory_events.cpp
+++ b/profiling/memory-events/kp_memory_events.cpp
@@ -72,8 +72,9 @@ void kokkosp_finalize_library() {
 
   for (int s = 0; s < num_spaces; s++) {
     char* fileOutput = (char*)malloc(sizeof(char) * 256);
-    snprintf(fileOutput, 256, "%s-%d-%s.memspace_usage", hostname, pid,
-             space_name[s]);
+    [[maybe_unused]] auto written_bytes =
+        snprintf(fileOutput, 256, "%s-%d-%s.memspace_usage", hostname, pid,
+                 space_name[s]);
 
     FILE* ofile = fopen(fileOutput, "wb");
     free(fileOutput);

--- a/profiling/memory-events/kp_memory_events.cpp
+++ b/profiling/memory-events/kp_memory_events.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
+#include <array>
 #include <cstdio>
 #include <cinttypes>
 #include <vector>
@@ -14,6 +15,8 @@
 #include "kp_core.hpp"
 #include "kp_memory_events.hpp"
 #include "kp_timer.hpp"
+
+#include <fstream>
 
 namespace KokkosTools {
 namespace MemoryEvents {
@@ -50,31 +53,31 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
 }
 
 void kokkosp_finalize_library() {
-  char* hostname = (char*)malloc(sizeof(char) * 256);
-  gethostname(hostname, 256);
+  std::array<char, 256> hostname_buf{};
+  gethostname(hostname_buf.data(), hostname_buf.size());
+  std::string hostname(hostname_buf.data());
+
   int pid = getpid();
 
-  {
-    char* fileOutput = (char*)malloc(sizeof(char) * 256);
-    snprintf(fileOutput, 256, "%s-%d.mem_events", hostname, pid);
+  std::string fileOutput = hostname + "-" + std::to_string(pid) + ".mem_events";
 
-    FILE* ofile = fopen(fileOutput, "wb");
-    free(fileOutput);
+  std::ofstream ofile(fileOutput, std::ios::binary);
 
-    fprintf(ofile, "# Memory Events\n");
-    fprintf(ofile,
-            "# Time     Ptr                  Size        MemSpace      Op      "
-            "   Name\n");
-    for (unsigned int i = 0; i < events.size(); i++)
-      events[i].print_record(ofile);
-    fclose(ofile);
+  ofile << "# Memory Events\n";
+  ofile << "# Time     Ptr                  Size        MemSpace      Op"
+        << "         Name\n";
+
+  for (const auto& e : events) {
+    e.print_record(ofile);  // assuming you overload to accept std::ostream
   }
+
+  ofile.close();
 
   for (int s = 0; s < num_spaces; s++) {
     char* fileOutput = (char*)malloc(sizeof(char) * 256);
     [[maybe_unused]] auto written_bytes =
-        snprintf(fileOutput, 256, "%s-%d-%s.memspace_usage", hostname, pid,
-                 space_name[s]);
+        snprintf(fileOutput, 256, "%s-%d-%s.memspace_usage", hostname.c_str(),
+                 pid, space_name[s]);
 
     FILE* ofile = fopen(fileOutput, "wb");
     free(fileOutput);
@@ -94,7 +97,6 @@ void kokkosp_finalize_library() {
     }
     fclose(ofile);
   }
-  free(hostname);
 }
 
 void kokkosp_allocate_data(const SpaceHandle space, const char* label,

--- a/profiling/memory-events/kp_memory_events.hpp
+++ b/profiling/memory-events/kp_memory_events.hpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <inttypes.h>
 #include <iomanip>
+#include <iosfwd>
 
 #include "kp_core.hpp"
 

--- a/profiling/memory-events/kp_memory_events.hpp
+++ b/profiling/memory-events/kp_memory_events.hpp
@@ -7,8 +7,6 @@
 
 #include <cstdio>
 #include <inttypes.h>
-#include <iomanip>
-#include <iosfwd>
 
 #include "kp_core.hpp"
 
@@ -35,26 +33,17 @@ struct EventRecord {
     strncpy(name, name_, 256);
   }
 
-  void print_record(std::ostream& os) const {
-    if (operation == MEMOP_ALLOCATE) {
-      os << time << " " << std::setw(16) << ptr << " " << std::setw(14) << size
-         << " " << std::setw(16) << (space < 0 ? "" : space_name[space]) << " "
-         << "Allocate   " << name << "\n";
-    }
-
-    if (operation == MEMOP_DEALLOCATE) {
-      os << time << " " << std::setw(16) << ptr << " " << std::setw(14) << -size
-         << " " << std::setw(16) << (space < 0 ? "" : space_name[space]) << " "
-         << "DeAllocate " << name << "\n";
-    }
-
-    if (operation == MEMOP_PUSH_REGION) {
-      os << time << " PushRegion " << name << " {\n";
-    }
-
-    if (operation == MEMOP_POP_REGION) {
-      os << time << " } PopRegion " << name << "\n";
-    }
+  void print_record(FILE* ofile) const {
+    if (operation == MEMOP_ALLOCATE)
+      fprintf(ofile, "%lf %16p %14" PRId64 " %16s Allocate   %s\n", time, ptr,
+              size, space < 0 ? "" : space_name[space], name);
+    if (operation == MEMOP_DEALLOCATE)
+      fprintf(ofile, "%lf %16p %14" PRId64 " %16s DeAllocate %s\n", time, ptr,
+              -size, space < 0 ? "" : space_name[space], name);
+    if (operation == MEMOP_PUSH_REGION)
+      fprintf(ofile, "%lf PushRegion %s {\n", time, name);
+    if (operation == MEMOP_POP_REGION)
+      fprintf(ofile, "%lf } PopRegion %s\n", time, name);
   }
 };
 

--- a/profiling/memory-events/kp_memory_events.hpp
+++ b/profiling/memory-events/kp_memory_events.hpp
@@ -7,6 +7,7 @@
 
 #include <cstdio>
 #include <inttypes.h>
+#include <iomanip>
 
 #include "kp_core.hpp"
 
@@ -33,17 +34,26 @@ struct EventRecord {
     strncpy(name, name_, 256);
   }
 
-  void print_record(FILE* ofile) const {
-    if (operation == MEMOP_ALLOCATE)
-      fprintf(ofile, "%lf %16p %14" PRId64 " %16s Allocate   %s\n", time, ptr,
-              size, space < 0 ? "" : space_name[space], name);
-    if (operation == MEMOP_DEALLOCATE)
-      fprintf(ofile, "%lf %16p %14" PRId64 " %16s DeAllocate %s\n", time, ptr,
-              -size, space < 0 ? "" : space_name[space], name);
-    if (operation == MEMOP_PUSH_REGION)
-      fprintf(ofile, "%lf PushRegion %s {\n", time, name);
-    if (operation == MEMOP_POP_REGION)
-      fprintf(ofile, "%lf } PopRegion %s\n", time, name);
+  void print_record(std::ostream& os) const {
+    if (operation == MEMOP_ALLOCATE) {
+      os << time << " " << std::setw(16) << ptr << " " << std::setw(14) << size
+         << " " << std::setw(16) << (space < 0 ? "" : space_name[space]) << " "
+         << "Allocate   " << name << "\n";
+    }
+
+    if (operation == MEMOP_DEALLOCATE) {
+      os << time << " " << std::setw(16) << ptr << " " << std::setw(14) << -size
+         << " " << std::setw(16) << (space < 0 ? "" : space_name[space]) << " "
+         << "DeAllocate " << name << "\n";
+    }
+
+    if (operation == MEMOP_PUSH_REGION) {
+      os << time << " PushRegion " << name << " {\n";
+    }
+
+    if (operation == MEMOP_POP_REGION) {
+      os << time << " } PopRegion " << name << "\n";
+    }
   }
 };
 

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -47,8 +47,8 @@ void kokkosp_init_library(const int /*loadSeq*/,
 void kokkosp_finalize_library() {
   char* hostname = (char*)malloc(sizeof(char) * 256);
   gethostname(hostname, 256);
-  int pid = getpid();
-  std::string hostname_string;
+  int pid                     = getpid();
+  std::string hostname_string = hostname;
 
   for (int s = 0; s < num_spaces; s++) {
     std::string fileOutput = hostname_string + "-" + std::to_string(pid) + "-" +

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
+#include <array>
 #include <cstdio>
 #include <inttypes.h>
 #include <vector>
@@ -8,6 +9,7 @@
 #include <atomic>
 #include <mutex>
 #include <fstream>
+#include <iomanip>
 
 #include <sys/resource.h>
 #include <unistd.h>

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <atomic>
 #include <mutex>
+#include <fstream>
 
 #include <sys/resource.h>
 #include <unistd.h>
@@ -45,34 +46,40 @@ void kokkosp_init_library(const int /*loadSeq*/,
 }
 
 void kokkosp_finalize_library() {
-  char* hostname = (char*)malloc(sizeof(char) * 256);
-  gethostname(hostname, 256);
+  std::array<char, 256> hostname_buf{};
+  gethostname(hostname_buf.data(), hostname_buf.size());
+  std::string hostname(hostname_buf.data());
+
   int pid = getpid();
 
-  for (int s = 0; s < num_spaces; s++) {
-    char* fileOutput = (char*)malloc(sizeof(char) * 256);
-    snprintf(fileOutput, 256, "%s-%d-%s.memspace_usage", hostname, pid,
-             space_name[s]);
+  std::string fileOutput = hostname + "-" + std::to_string(pid) + ".mem_events";
+  std::ofstream ofile(fileOutput, std::ios::binary);
 
-    FILE* ofile = fopen(fileOutput, "wb");
-    free(fileOutput);
+  for (int s = 0; s < num_spaces; ++s) {
+    std::string fileName = hostname + "-" + std::to_string(pid) + "-" +
+                           space_name[s] + ".memspace_usage";
 
-    fprintf(ofile, "# Space %s\n", space_name[s]);
-    fprintf(ofile,
-            "# Time(s)  Size(MB)   HighWater(MB)   HighWater-Process(MB)\n");
+    std::ofstream spaceFile(fileName, std::ios::binary);
+
+    spaceFile << "# Space " << space_name[s] << "\n";
+    spaceFile
+        << "# Time(s)  Size(MB)   HighWater(MB)   HighWater-Process(MB)\n";
+
     uint64_t maxvalue = 0;
-    for (unsigned int i = 0; i < space_size_track[s].size(); i++) {
-      if (std::get<1>(space_size_track[s][i]) > maxvalue)
-        maxvalue = std::get<1>(space_size_track[s][i]);
-      fprintf(ofile, "%lf %.1lf %.1lf %.1lf\n",
-              std::get<0>(space_size_track[s][i]),
-              1.0 * std::get<1>(space_size_track[s][i]) / 1024 / 1024,
-              1.0 * maxvalue / 1024 / 1024,
-              1.0 * std::get<2>(space_size_track[s][i]) / 1024 / 1024);
+
+    for (const auto& entry : space_size_track[s]) {
+      double time         = std::get<0>(entry);
+      uint64_t size       = std::get<1>(entry);
+      uint64_t process_hw = std::get<2>(entry);
+
+      if (size > maxvalue) maxvalue = size;
+
+      spaceFile << time << " " << std::fixed << std::setprecision(1)
+                << (size / 1024.0 / 1024.0) << " "
+                << (maxvalue / 1024.0 / 1024.0) << " "
+                << (process_hw / 1024.0 / 1024.0) << "\n";
     }
-    fclose(ofile);
   }
-  free(hostname);
 }
 
 void kokkosp_allocate_data(const SpaceHandle space, const char* /*label*/,

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -1,15 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#include <array>
 #include <cstdio>
 #include <inttypes.h>
 #include <vector>
 #include <unordered_map>
 #include <atomic>
 #include <mutex>
-#include <fstream>
-#include <iomanip>
 
 #include <sys/resource.h>
 #include <unistd.h>
@@ -48,40 +45,33 @@ void kokkosp_init_library(const int /*loadSeq*/,
 }
 
 void kokkosp_finalize_library() {
-  std::array<char, 256> hostname_buf{};
-  gethostname(hostname_buf.data(), hostname_buf.size());
-  std::string hostname(hostname_buf.data());
-
+  char* hostname = (char*)malloc(sizeof(char) * 256);
+  gethostname(hostname, 256);
   int pid = getpid();
+  std::string hostname_string;
 
-  std::string fileOutput = hostname + "-" + std::to_string(pid) + ".mem_events";
-  std::ofstream ofile(fileOutput, std::ios::binary);
+  for (int s = 0; s < num_spaces; s++) {
+    std::string fileOutput = hostname_string + "-" + std::to_string(pid) + "-" +
+                             space_name[s] + ".memspace_usage";
 
-  for (int s = 0; s < num_spaces; ++s) {
-    std::string fileName = hostname + "-" + std::to_string(pid) + "-" +
-                           space_name[s] + ".memspace_usage";
+    FILE* ofile = fopen(fileOutput.c_str(), "wb");
 
-    std::ofstream spaceFile(fileName, std::ios::binary);
-
-    spaceFile << "# Space " << space_name[s] << "\n";
-    spaceFile
-        << "# Time(s)  Size(MB)   HighWater(MB)   HighWater-Process(MB)\n";
-
+    fprintf(ofile, "# Space %s\n", space_name[s]);
+    fprintf(ofile,
+            "# Time(s)  Size(MB)   HighWater(MB)   HighWater-Process(MB)\n");
     uint64_t maxvalue = 0;
-
-    for (const auto& entry : space_size_track[s]) {
-      double time         = std::get<0>(entry);
-      uint64_t size       = std::get<1>(entry);
-      uint64_t process_hw = std::get<2>(entry);
-
-      if (size > maxvalue) maxvalue = size;
-
-      spaceFile << time << " " << std::fixed << std::setprecision(1)
-                << (size / 1024.0 / 1024.0) << " "
-                << (maxvalue / 1024.0 / 1024.0) << " "
-                << (process_hw / 1024.0 / 1024.0) << "\n";
+    for (unsigned int i = 0; i < space_size_track[s].size(); i++) {
+      if (std::get<1>(space_size_track[s][i]) > maxvalue)
+        maxvalue = std::get<1>(space_size_track[s][i]);
+      fprintf(ofile, "%lf %.1lf %.1lf %.1lf\n",
+              std::get<0>(space_size_track[s][i]),
+              1.0 * std::get<1>(space_size_track[s][i]) / 1024 / 1024,
+              1.0 * maxvalue / 1024 / 1024,
+              1.0 * std::get<2>(space_size_track[s][i]) / 1024 / 1024);
     }
+    fclose(ofile);
   }
+  free(hostname);
 }
 
 void kokkosp_allocate_data(const SpaceHandle space, const char* /*label*/,

--- a/profiling/papi-connector/kp_papi_connector.cpp
+++ b/profiling/papi-connector/kp_papi_connector.cpp
@@ -20,7 +20,7 @@ extern "C" void kokkosp_init_library(const int loadSeq,
                                      void* deviceInfo) {
   printf("-----------------------------------------------------------\n");
   printf("KokkosP: PAPI Connector (sequence is %d, version: %llu)\n", loadSeq,
-         interfaceVer);
+         static_cast<unsigned long long>(interfaceVer));
   printf("-----------------------------------------------------------\n");
 
   /* The following advanced functions of PAPI's high-level API are not part

--- a/profiling/perfetto-connector/CMakeLists.txt
+++ b/profiling/perfetto-connector/CMakeLists.txt
@@ -1,2 +1,3 @@
 kp_add_library(kp_perfetto_connector libperfetto-connector.cpp perfetto/perfetto.cc)
+target_compile_options(kp_perfetto_connector PRIVATE "-w")
 target_include_directories(kp_perfetto_connector PRIVATE perfetto)

--- a/profiling/simple-kernel-timer/kp_json_writer.cpp
+++ b/profiling/simple-kernel-timer/kp_json_writer.cpp
@@ -62,7 +62,7 @@ int main(int argc, char* argv[]) {
     FILE* the_file = fopen(argv[i], "rb");
 
     double fileExecuteTime = 0;
-    fread(&fileExecuteTime, sizeof(fileExecuteTime), 1, the_file);
+    (void)fread(&fileExecuteTime, sizeof(fileExecuteTime), 1, the_file);
 
     totalExecuteTime += fileExecuteTime;
 

--- a/profiling/simple-kernel-timer/kp_json_writer.cpp
+++ b/profiling/simple-kernel-timer/kp_json_writer.cpp
@@ -62,7 +62,7 @@ int main(int argc, char* argv[]) {
     FILE* the_file = fopen(argv[i], "rb");
 
     double fileExecuteTime = 0;
-    [[maybe_unused]] auto dummy =
+    [[maybe_unused]] auto ignore =
         fread(&fileExecuteTime, sizeof(fileExecuteTime), 1, the_file);
 
     totalExecuteTime += fileExecuteTime;

--- a/profiling/simple-kernel-timer/kp_json_writer.cpp
+++ b/profiling/simple-kernel-timer/kp_json_writer.cpp
@@ -62,7 +62,8 @@ int main(int argc, char* argv[]) {
     FILE* the_file = fopen(argv[i], "rb");
 
     double fileExecuteTime = 0;
-    (void)fread(&fileExecuteTime, sizeof(fileExecuteTime), 1, the_file);
+    [[maybe_unused]] auto dummy =
+        fread(&fileExecuteTime, sizeof(fileExecuteTime), 1, the_file);
 
     totalExecuteTime += fileExecuteTime;
 

--- a/profiling/simple-kernel-timer/kp_kernel_info.h
+++ b/profiling/simple-kernel-timer/kp_kernel_info.h
@@ -64,8 +64,9 @@ class KernelPerformanceInfo {
     uint32_t actual_read = fread(&recordLen, sizeof(recordLen), 1, input);
     if (actual_read != 1) return false;
 
-    char* entry = (char*)malloc(recordLen);
-    fread(entry, recordLen, 1, input);
+    char* entry       = (char*)malloc(recordLen);
+    auto read_objects = fread(entry, recordLen, 1, input);
+    if (read_objects != 1) return false;
 
     uint32_t nextIndex = 0;
     uint32_t kernelNameLength;

--- a/profiling/simple-kernel-timer/kp_kernel_timer.cpp
+++ b/profiling/simple-kernel-timer/kp_kernel_timer.cpp
@@ -133,8 +133,11 @@ void kokkosp_finalize_library() {
   fclose(output_data);
 
   char currentwd[256];
-  getcwd(currentwd, 256);
-  printf("KokkosP: Kernel timing written to %s/%s \n", currentwd, fileOutput);
+  auto return_value = getcwd(currentwd, 256);
+  if (return_value)
+    printf("KokkosP: Kernel timing written to %s/%s \n", currentwd, fileOutput);
+  else
+    printf("KokkosP: Couldn't read current working directory.\n");
 
   /*printf("\n");
   printf("======================================================================\n");

--- a/profiling/simple-kernel-timer/kp_kernel_timer.cpp
+++ b/profiling/simple-kernel-timer/kp_kernel_timer.cpp
@@ -133,9 +133,8 @@ void kokkosp_finalize_library() {
 
   fclose(output_data);
 
-  auto currentwd = std::filesystem::current_path();
-  printf("KokkosP: Kernel timing written to %s/%s \n", currentwd.c_str(),
-         fileOutput);
+  auto cwd = std::filesystem::current_path();
+  printf("KokkosP: Kernel timing written to %s/%s \n", cwd.c_str(), fileOutput);
 
   /*printf("\n");
   printf("======================================================================\n");

--- a/profiling/simple-kernel-timer/kp_kernel_timer.cpp
+++ b/profiling/simple-kernel-timer/kp_kernel_timer.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <iostream>
 #include <unistd.h>
+#include <filesystem>
 
 #include "kp_core.hpp"
 #include "kp_shared.h"
@@ -132,12 +133,9 @@ void kokkosp_finalize_library() {
 
   fclose(output_data);
 
-  char currentwd[256];
-  auto return_value = getcwd(currentwd, 256);
-  if (return_value)
-    printf("KokkosP: Kernel timing written to %s/%s \n", currentwd, fileOutput);
-  else
-    printf("KokkosP: Couldn't read current working directory.\n");
+  auto currentwd = std::filesystem::current_path();
+  printf("KokkosP: Kernel timing written to %s/%s \n", currentwd.c_str(),
+         fileOutput);
 
   /*printf("\n");
   printf("======================================================================\n");

--- a/profiling/simple-kernel-timer/kp_reader.cpp
+++ b/profiling/simple-kernel-timer/kp_reader.cpp
@@ -43,7 +43,7 @@ int main(int argc, char* argv[]) {
     FILE* the_file = fopen(argv[i], "rb");
 
     double fileExecuteTime = 0;
-    fread(&fileExecuteTime, sizeof(fileExecuteTime), 1, the_file);
+    (void)fread(&fileExecuteTime, sizeof(fileExecuteTime), 1, the_file);
 
     totalExecuteTime += fileExecuteTime;
 

--- a/profiling/simple-kernel-timer/kp_reader.cpp
+++ b/profiling/simple-kernel-timer/kp_reader.cpp
@@ -43,7 +43,7 @@ int main(int argc, char* argv[]) {
     FILE* the_file = fopen(argv[i], "rb");
 
     double fileExecuteTime = 0;
-    [[maybe_unused]] auto dummy =
+    [[maybe_unused]] auto ignore =
         fread(&fileExecuteTime, sizeof(fileExecuteTime), 1, the_file);
 
     totalExecuteTime += fileExecuteTime;

--- a/profiling/simple-kernel-timer/kp_reader.cpp
+++ b/profiling/simple-kernel-timer/kp_reader.cpp
@@ -43,7 +43,8 @@ int main(int argc, char* argv[]) {
     FILE* the_file = fopen(argv[i], "rb");
 
     double fileExecuteTime = 0;
-    (void)fread(&fileExecuteTime, sizeof(fileExecuteTime), 1, the_file);
+    [[maybe_unused]] auto dummy =
+        fread(&fileExecuteTime, sizeof(fileExecuteTime), 1, the_file);
 
     totalExecuteTime += fileExecuteTime;
 


### PR DESCRIPTION
- Disable warnings in TPLs
- Rework C-style implementations of `kokkosp_finalize_library` and `print_records` in `kp_memory_usage`/`kp_memory_events`.
- Build in verbose mode.