### PR TITLE
fix(kernel-time): correct total/kernel time calculation in JSON output

### DIFF
--- a/profiling/simple-kernel-timer/CMakeLists.txt
+++ b/profiling/simple-kernel-timer/CMakeLists.txt
@@ -16,4 +16,4 @@ kp_add_executable(kp_reader kp_reader.cpp)
 target_link_libraries(kp_reader PRIVATE kp_kernel_timer)
 
 kp_add_executable(kp_json_writer kp_json_writer.cpp)
-target_link_libraries(kp_json_writer PRIVATE kp_kernel_timer)
+target_link_libraries(kp_json_writer PRIVATE kp_kernel_timer kp_kernel_shared)

--- a/profiling/simple-kernel-timer/kp_json_writer.cpp
+++ b/profiling/simple-kernel-timer/kp_json_writer.cpp
@@ -9,36 +9,27 @@
 #include <map>
 #include <fstream>
 #include <iostream>
-
 #include "kp_shared.h"
 
 using namespace KokkosTools::KernelTimer;
 
-bool is_region(KernelPerformanceInfo const& kp) {
-  return kp.getKernelType() == REGION;
-}
+void fill_info(FILE* file, std::vector<KernelPerformanceInfo*>& kernelInfo) {
+  while (!feof(file)) {
+    KernelPerformanceInfo* new_kernel =
+        new KernelPerformanceInfo("", PARALLEL_FOR);
+    if (new_kernel->readFromFile(file)) {
+      if (!new_kernel->getName().empty()) {
+        int kernelIndex = find_index(kernelInfo, new_kernel->getName());
 
-inline std::string to_string(KernelExecutionType t) {
-  switch (t) {
-    case PARALLEL_FOR: return "\"PARALLEL_FOR\"";
-    case PARALLEL_REDUCE: return "\"PARALLEL_REDUCE\"";
-    case PARALLEL_SCAN: return "\"PARALLEL_SCAN\"";
-    case REGION: return "\"REGION\"";
-    default: throw t;
+        if (kernelIndex > -1) {
+          kernelInfo[kernelIndex]->addTime(new_kernel->getTime());
+          kernelInfo[kernelIndex]->addCallCount(new_kernel->getCallCount());
+        } else {
+          kernelInfo.push_back(new_kernel);
+        }
+      }
+    }
   }
-}
-
-inline void write_json(std::ostream& os, KernelPerformanceInfo const& kp,
-                       std::string indent = "") {
-  os << indent << "{\n";
-  os << indent << "  \"kernel-name\": \"" << kp.getName() << "\",\n";
-  os << indent << "  \"call-count\": " << kp.getCallCount() << ",\n";
-  os << indent << "  \"total-time\": " << kp.getTime() << ",\n";
-  os << indent << "  \"time-per-call\": "
-     << kp.getTime() / std::max((uint64_t)1, kp.getCallCount()) << ",\n";
-  os << indent << "  \"kernel-type\": " << to_string(kp.getKernelType())
-     << '\n';
-  os << indent << '}';
 }
 
 int main(int argc, char* argv[]) {
@@ -54,9 +45,8 @@ int main(int argc, char* argv[]) {
   }
 
   std::vector<KernelPerformanceInfo*> kernelInfo;
-  double totalKernelsTime    = 0;
-  double totalExecuteTime    = 0;
-  uint64_t totalKernelsCalls = 0;
+
+  double totalExecuteTime = 0;
 
   for (int i = commandline_args; i < argc; i++) {
     FILE* the_file = fopen(argv[i], "rb");
@@ -66,76 +56,12 @@ int main(int argc, char* argv[]) {
 
     totalExecuteTime += fileExecuteTime;
 
-    while (!feof(the_file)) {
-      KernelPerformanceInfo* new_kernel =
-          new KernelPerformanceInfo("", PARALLEL_FOR);
-      if (new_kernel->readFromFile(the_file)) {
-        if (!new_kernel->getName().empty()) {
-          int kernelIndex = find_index(kernelInfo, new_kernel->getName());
-
-          if (kernelIndex > -1) {
-            kernelInfo[kernelIndex]->addTime(new_kernel->getTime());
-            kernelInfo[kernelIndex]->addCallCount(new_kernel->getCallCount());
-          } else {
-            kernelInfo.push_back(new_kernel);
-          }
-        }
-      }
-    }
+    fill_info(the_file, kernelInfo);
 
     fclose(the_file);
   }
-
-  std::sort(kernelInfo.begin(), kernelInfo.end(), compareKernelPerformanceInfo);
-
-  for (unsigned int i = 0; i < kernelInfo.size(); i++) {
-    if (kernelInfo[i]->getKernelType() != REGION) {
-      totalKernelsTime += kernelInfo[i]->getTime();
-      totalKernelsCalls += kernelInfo[i]->getCallCount();
-    }
-  }
-
-  // std::string filename = "test.json";
-  // std::ofstream fout(filename);
-  auto& fout = std::cout;
-
-  fout << "{\n";
-
-  fout << "  \"total-app-time\" : " << totalExecuteTime << ",\n";
-  fout << "  \"total-kernel-time\" : " << totalKernelsTime << ",\n";
-  fout << "  \"total-non-kernel-time\" : "
-       << totalExecuteTime - totalKernelsTime << ",\n";
-  fout << "  \"percent-in-kernels\" : "
-       << 100. * totalKernelsTime / totalExecuteTime << ",\n";
-  fout << "  \"unique-kernel-calls\" : " << totalKernelsCalls << ",\n";
-
-  fout << "  \"region-data\" : [\n";
-  {
-    bool add_comma = false;
-    for (auto const& kp : kernelInfo) {
-      if (!is_region(*kp)) continue;
-      if (add_comma) fout << ",\n";
-      add_comma = true;
-      write_json(fout, *kp, "    ");
-    }
-    fout << '\n';
-  }
-  fout << "  ],\n";
-
-  fout << "  \"kernel-data\" : [\n";
-  {
-    bool add_comma = false;
-    for (auto const& kp : kernelInfo) {
-      if (is_region(*kp)) continue;
-      if (add_comma) fout << ",\n";
-      add_comma = true;
-      write_json(fout, *kp, "    ");
-    }
-    fout << '\n';
-  }
-  fout << "  ]\n";
-
-  fout << "}\n";
+  std::ostream& fout = std::cout;
+  json_format_kernel_list(totalExecuteTime, kernelInfo, fout);
 
   return 0;
 }

--- a/profiling/simple-kernel-timer/kp_kernel_info.h
+++ b/profiling/simple-kernel-timer/kp_kernel_info.h
@@ -8,8 +8,6 @@
 #include <sys/time.h>
 #include <string>
 #include <cstring>
-
-#include "kp_shared.h"
 #include "utils/demangle.hpp"
 
 namespace KokkosTools::KernelTimer {

--- a/profiling/simple-kernel-timer/kp_kernel_info.h
+++ b/profiling/simple-kernel-timer/kp_kernel_info.h
@@ -138,35 +138,6 @@ class KernelPerformanceInfo {
     free(entry);
   }
 
-  void writeToJSONFile(FILE* output, const char* indent) {
-    fprintf(output, "%s{\n", indent);
-
-    char* indentBuffer = (char*)malloc(sizeof(char) * 256);
-    snprintf(indentBuffer, 256, "%s    ", indent);
-
-    auto name = kernelName.c_str();
-    if (kType == REGION) {
-      fprintf(output, "%s\"region-name\"    : \"%s\",\n", indentBuffer, name);
-    } else {
-      fprintf(output, "%s\"kernel-name\"    : \"%s\",\n", indentBuffer, name);
-    }
-
-    // fprintf(output, "%s\"region\"         : \"%s\",\n", indentBuffer,
-    // regionName);
-    fprintf(output, "%s\"call-count\"     : %llu,\n", indentBuffer,
-            (unsigned long long)(callCount));
-    fprintf(output, "%s\"total-time\"     : %f,\n", indentBuffer, time);
-    fprintf(output, "%s\"time-per-call\"  : %16.8f,\n", indentBuffer,
-            (time / static_cast<double>(
-                        std::max(static_cast<uint64_t>(1), callCount))));
-    fprintf(output, "%s\"kernel-type\"    : \"%s\"\n", indentBuffer,
-            (kType == PARALLEL_FOR)      ? "PARALLEL-FOR"
-            : (kType == PARALLEL_REDUCE) ? "PARALLEL-REDUCE"
-                                         : "PARALLEL-SCAN");
-
-    fprintf(output, "%s}", indent);
-  }
-
  private:
   void copy(char* dest, const char* src, uint32_t len) {
     for (uint32_t i = 0; i < len; i++) {

--- a/profiling/simple-kernel-timer/kp_kernel_info.h
+++ b/profiling/simple-kernel-timer/kp_kernel_info.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstring>
 
+#include "kp_shared.h"
 #include "utils/demangle.hpp"
 
 namespace KokkosTools::KernelTimer {
@@ -144,8 +145,13 @@ class KernelPerformanceInfo {
     char* indentBuffer = (char*)malloc(sizeof(char) * 256);
     snprintf(indentBuffer, 256, "%s    ", indent);
 
-    fprintf(output, "%s\"kernel-name\"    : \"%s\",\n", indentBuffer,
-            kernelName.c_str());
+    auto name = kernelName.c_str();
+    if (kType == REGION) {
+      fprintf(output, "%s\"region-name\"    : \"%s\",\n", indentBuffer, name);
+    } else {
+      fprintf(output, "%s\"kernel-name\"    : \"%s\",\n", indentBuffer, name);
+    }
+
     // fprintf(output, "%s\"region\"         : \"%s\",\n", indentBuffer,
     // regionName);
     fprintf(output, "%s\"call-count\"     : %llu,\n", indentBuffer,

--- a/profiling/simple-kernel-timer/kp_kernel_timer.cpp
+++ b/profiling/simple-kernel-timer/kp_kernel_timer.cpp
@@ -6,7 +6,7 @@
 #include <iostream>
 #include <unistd.h>
 #include <filesystem>
-
+#include <algorithm>
 #include "kp_core.hpp"
 #include "kp_shared.h"
 #include <sstream>

--- a/profiling/simple-kernel-timer/kp_kernel_timer.cpp
+++ b/profiling/simple-kernel-timer/kp_kernel_timer.cpp
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <vector>
-#include <algorithm>
 #include <string>
 #include <iostream>
 #include <unistd.h>
@@ -47,8 +46,6 @@ void kokkosp_finalize_library() {
           : strcmp(kokkos_tools_timer_json_raw, "1") == 0 ||
                 strcmp(kokkos_tools_timer_json_raw, "true") == 0 ||
                 strcmp(kokkos_tools_timer_json_raw, "True") == 0;
-
-  double kernelTimes = 0;
 
   char* hostname = (char*)malloc(sizeof(char) * 256);
   gethostname(hostname, 256);

--- a/profiling/simple-kernel-timer/kp_kernel_timer.cpp
+++ b/profiling/simple-kernel-timer/kp_kernel_timer.cpp
@@ -123,7 +123,7 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
 
   initTime = seconds();
 }
-#define KERNEL_INFO_INDENT "       "
+
 void kokkosp_finalize_library() {
   double finishTime             = seconds();
   const double totalExecuteTime = (finishTime - initTime);

--- a/profiling/simple-kernel-timer/kp_kernel_timer.cpp
+++ b/profiling/simple-kernel-timer/kp_kernel_timer.cpp
@@ -10,6 +10,7 @@
 #include "kp_core.hpp"
 #include "kp_shared.h"
 #include <sstream>
+#include <locale>
 namespace KokkosTools {
 namespace KernelTimer {
 void print_ascii(std::map<std::string, KernelPerformanceInfo*>& count_map,
@@ -172,7 +173,8 @@ void kokkosp_finalize_library() {
     }
 
     std::ostringstream buffer;
-
+    // Ensure that JSON formatting won't be broken
+    buffer.imbue(std::locale::classic());
     json_format_kernel_list(totalExecuteTime, kernelList, buffer);
 
     const std::string& s = buffer.str();

--- a/profiling/simple-kernel-timer/kp_kernel_timer.cpp
+++ b/profiling/simple-kernel-timer/kp_kernel_timer.cpp
@@ -9,13 +9,9 @@
 
 #include "kp_core.hpp"
 #include "kp_shared.h"
-
+#include <sstream>
 namespace KokkosTools {
 namespace KernelTimer {
-
-bool is_region(KernelPerformanceInfo const& kp) {
-  return kp.getKernelType() == REGION;
-}
 
 void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
                           const uint32_t /*devInfoCount*/,
@@ -74,73 +70,20 @@ void kokkosp_finalize_library() {
     }
   } else {
     std::vector<KernelPerformanceInfo*> kernelList;
-    const std::size_t unique_counts        = count_map.size();
-    unsigned long long unique_kernel_count = 0;
+    const std::size_t unique_counts = count_map.size();
     kernelList.reserve(unique_counts);
 
     for (auto kernel_itr = count_map.begin(); kernel_itr != count_map.end();
          kernel_itr++) {
-      // Skip region to not count twice
-      if (!is_region(*kernel_itr->second)) {
-        kernelTimes += kernel_itr->second->getTime();
-        unique_kernel_count++;
-      }
       kernelList.push_back(kernel_itr->second);
     }
 
-    std::sort(kernelList.begin(), kernelList.end(),
-              compareKernelPerformanceInfo);
-    const double percentKokkos = (kernelTimes / totalExecuteTime) * 100.0;
-    const double nonKernelTime = totalExecuteTime - kernelTimes;
+    std::ostringstream buffer;
 
-    fprintf(output_data, "{\n\"kokkos-kernel-data\" : {\n");
-    fprintf(output_data, "    \"total-app-time\"         : %10.3f,\n",
-            totalExecuteTime);
-    fprintf(output_data, "    \"total-kernel-times\"     : %10.3f,\n",
-            kernelTimes);
-    fprintf(output_data, "    \"total-non-kernel-times\" : %10.3f,\n",
-            nonKernelTime);
+    json_format_kernel_list(totalExecuteTime, kernelList, buffer);
 
-    fprintf(output_data, "    \"percent-in-kernels\"     : %6.2f,\n",
-            percentKokkos);
-    fprintf(output_data, "    \"unique-kernel-calls\"    : %22llu,\n",
-            unique_kernel_count);
-    fprintf(output_data, "\n");
-
-    fprintf(output_data, "    \"region-perf-info\"       : [\n");
-
-    bool print_comma = false;
-    for (auto const& kernel : count_map) {
-      if (!is_region(*std::get<1>(kernel))) {
-        continue;
-      }
-      if (print_comma) {
-        fprintf(output_data, ",\n");
-      }
-      kernel.second->writeToJSONFile(output_data, KERNEL_INFO_INDENT);
-      print_comma = true;
-    }
-
-    fprintf(output_data, "\n");
-    fprintf(output_data, "    ],\n");
-    fprintf(output_data, "    \"kernel-perf-info\"       : [\n");
-
-    print_comma = false;
-    for (auto const& kernel : count_map) {
-      if (is_region(*std::get<1>(kernel))) {
-        continue;
-      }
-      if (print_comma) {
-        fprintf(output_data, ",\n");
-      }
-      kernel.second->writeToJSONFile(output_data, KERNEL_INFO_INDENT);
-      print_comma = true;
-    }
-
-    fprintf(output_data, "\n");
-    fprintf(output_data, "    ]\n");
-
-    fprintf(output_data, "}\n}");
+    const std::string& s = buffer.str();
+    fwrite(s.data(), 1, s.size(), output_data);
   }
 
   fclose(output_data);

--- a/profiling/simple-kernel-timer/kp_kernel_timer.cpp
+++ b/profiling/simple-kernel-timer/kp_kernel_timer.cpp
@@ -40,7 +40,7 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
 
   initTime = seconds();
 }
-
+#define KERNEL_INFO_INDENT "       "
 void kokkosp_finalize_library() {
   double finishTime = seconds();
 
@@ -74,15 +74,24 @@ void kokkosp_finalize_library() {
     }
   } else {
     std::vector<KernelPerformanceInfo*> kernelList;
+    const std::size_t unique_counts        = count_map.size();
+    unsigned long long unique_kernel_count = 0;
+    kernelList.reserve(unique_counts);
 
     for (auto kernel_itr = count_map.begin(); kernel_itr != count_map.end();
          kernel_itr++) {
+      // Skip region to not count twice
+      if (!is_region(*kernel_itr->second)) {
+        kernelTimes += kernel_itr->second->getTime();
+        unique_kernel_count++;
+      }
       kernelList.push_back(kernel_itr->second);
-      kernelTimes += kernel_itr->second->getTime();
     }
 
     std::sort(kernelList.begin(), kernelList.end(),
               compareKernelPerformanceInfo);
+    const double percentKokkos = (kernelTimes / totalExecuteTime) * 100.0;
+    const double nonKernelTime = totalExecuteTime - kernelTimes;
 
     fprintf(output_data, "{\n\"kokkos-kernel-data\" : {\n");
     fprintf(output_data, "    \"total-app-time\"         : %10.3f,\n",
@@ -90,36 +99,40 @@ void kokkosp_finalize_library() {
     fprintf(output_data, "    \"total-kernel-times\"     : %10.3f,\n",
             kernelTimes);
     fprintf(output_data, "    \"total-non-kernel-times\" : %10.3f,\n",
-            (totalExecuteTime - kernelTimes));
+            nonKernelTime);
 
-    const double percentKokkos = (kernelTimes / totalExecuteTime) * 100.0;
     fprintf(output_data, "    \"percent-in-kernels\"     : %6.2f,\n",
             percentKokkos);
     fprintf(output_data, "    \"unique-kernel-calls\"    : %22llu,\n",
-            (unsigned long long)count_map.size());
+            unique_kernel_count);
     fprintf(output_data, "\n");
 
     fprintf(output_data, "    \"region-perf-info\"       : [\n");
 
-#define KERNEL_INFO_INDENT "       "
-
     bool print_comma = false;
     for (auto const& kernel : count_map) {
-      if (!is_region(*std::get<1>(kernel))) continue;
-      if (print_comma) fprintf(output_data, ",\n");
+      if (!is_region(*std::get<1>(kernel))) {
+        continue;
+      }
+      if (print_comma) {
+        fprintf(output_data, ",\n");
+      }
       kernel.second->writeToJSONFile(output_data, KERNEL_INFO_INDENT);
       print_comma = true;
     }
 
     fprintf(output_data, "\n");
     fprintf(output_data, "    ],\n");
-
     fprintf(output_data, "    \"kernel-perf-info\"       : [\n");
 
     print_comma = false;
     for (auto const& kernel : count_map) {
-      if (is_region(*std::get<1>(kernel))) continue;
-      if (print_comma) fprintf(output_data, ",\n");
+      if (is_region(*std::get<1>(kernel))) {
+        continue;
+      }
+      if (print_comma) {
+        fprintf(output_data, ",\n");
+      }
       kernel.second->writeToJSONFile(output_data, KERNEL_INFO_INDENT);
       print_comma = true;
     }

--- a/profiling/simple-kernel-timer/kp_shared.cpp
+++ b/profiling/simple-kernel-timer/kp_shared.cpp
@@ -62,6 +62,7 @@ inline std::string to_string(KernelExecutionType t) {
 
 inline void write_json(std::ostream& os, KernelPerformanceInfo const& kp,
                        std::string indent = "") {
+  const uint64_t callcount = kp.getCallCount();
   os << indent << "{\n";
   if (is_region(kp)) {
     os << indent << "  \"region-name\": \"" << kp.getName() << "\",\n";
@@ -69,10 +70,10 @@ inline void write_json(std::ostream& os, KernelPerformanceInfo const& kp,
     os << indent << "  \"kernel-name\": \"" << kp.getName() << "\",\n";
   }
 
-  os << indent << "  \"call-count\": " << kp.getCallCount() << ",\n";
+  os << indent << "  \"call-count\": " << callcount << ",\n";
   os << indent << "  \"total-time\": " << kp.getTime() << ",\n";
   os << indent << "  \"time-per-call\": "
-     << kp.getTime() / std::max((uint64_t)1, kp.getCallCount()) << ",\n";
+     << kp.getTime() / std::max((uint64_t)1, callcount) << ",\n";
   os << indent << "  \"kernel-type\": " << to_string(kp.getKernelType())
      << '\n';
   os << indent << '}';
@@ -87,12 +88,10 @@ void json_format_kernel_list(double totalExecuteTime,
   for (unsigned int i = 0; i < kernelInfo.size(); i++) {
     if (kernelInfo[i]->getKernelType() != REGION) {
       totalKernelsTime += kernelInfo[i]->getTime();
-      totalKernelsCalls += kernelInfo[i]->getCallCount();
+      // totalKernelsCalls += kernelInfo[i]->getCallCount();
+      totalKernelsCalls++;
     }
   }
-
-  // std::string filename = "test.json";
-  // std::ofstream fout(filename);
 
   fout << "{\n";
 

--- a/profiling/simple-kernel-timer/kp_shared.cpp
+++ b/profiling/simple-kernel-timer/kp_shared.cpp
@@ -83,27 +83,29 @@ void json_format_kernel_list(double totalExecuteTime,
                              std::vector<KernelPerformanceInfo*>& kernelInfo,
                              std::ostream& fout) {
   std::sort(kernelInfo.begin(), kernelInfo.end(), compareKernelPerformanceInfo);
-  uint64_t totalKernelsCalls = 0;
-  double totalKernelsTime    = 0;
+  uint64_t uniqueKernelsCalls = 0;
+  double totalKernelsTime     = 0;
+  // Iterate over all records.
   for (unsigned int i = 0; i < kernelInfo.size(); i++) {
+    // Exclude regions so that only kernels are included in the statistics
     if (kernelInfo[i]->getKernelType() != REGION) {
       totalKernelsTime += kernelInfo[i]->getTime();
-      // totalKernelsCalls += kernelInfo[i]->getCallCount();
-      totalKernelsCalls++;
+      uniqueKernelsCalls++;
     }
   }
+
+  const auto nonKernelTIme     = totalExecuteTime - totalKernelsTime;
+  const auto percentageKernels = 100. * totalKernelsTime / totalExecuteTime;
 
   fout << "{\n";
 
   fout << "  \"total-app-time\" : " << totalExecuteTime << ",\n";
   fout << "  \"total-kernel-time\" : " << totalKernelsTime << ",\n";
-  fout << "  \"total-non-kernel-time\" : "
-       << totalExecuteTime - totalKernelsTime << ",\n";
-  fout << "  \"percent-in-kernels\" : "
-       << 100. * totalKernelsTime / totalExecuteTime << ",\n";
-  fout << "  \"unique-kernel-calls\" : " << totalKernelsCalls << ",\n";
-
+  fout << "  \"total-non-kernel-time\" : " << nonKernelTIme << ",\n";
+  fout << "  \"percent-in-kernels\" : " << percentageKernels << ",\n";
+  fout << "  \"unique-kernel-calls\" : " << uniqueKernelsCalls << ",\n";
   fout << "  \"region-data\" : [\n";
+
   {
     bool add_comma = false;
     for (auto const& kp : kernelInfo) {

--- a/profiling/simple-kernel-timer/kp_shared.cpp
+++ b/profiling/simple-kernel-timer/kp_shared.cpp
@@ -3,6 +3,9 @@
 
 #include "kp_shared.h"
 
+#include <ostream>
+#include <algorithm>
+
 namespace KokkosTools {
 namespace KernelTimer {
 
@@ -45,6 +48,89 @@ void increment_counter_region(const char* name, KernelExecutionType kType) {
 
   regions[current_region_level]->startTimer();
   current_region_level++;
+}
+
+inline std::string to_string(KernelExecutionType t) {
+  switch (t) {
+    case PARALLEL_FOR: return "\"PARALLEL_FOR\"";
+    case PARALLEL_REDUCE: return "\"PARALLEL_REDUCE\"";
+    case PARALLEL_SCAN: return "\"PARALLEL_SCAN\"";
+    case REGION: return "\"REGION\"";
+    default: throw t;
+  }
+}
+
+inline void write_json(std::ostream& os, KernelPerformanceInfo const& kp,
+                       std::string indent = "") {
+  os << indent << "{\n";
+  if (is_region(kp)) {
+    os << indent << "  \"region-name\": \"" << kp.getName() << "\",\n";
+  } else {
+    os << indent << "  \"kernel-name\": \"" << kp.getName() << "\",\n";
+  }
+
+  os << indent << "  \"call-count\": " << kp.getCallCount() << ",\n";
+  os << indent << "  \"total-time\": " << kp.getTime() << ",\n";
+  os << indent << "  \"time-per-call\": "
+     << kp.getTime() / std::max((uint64_t)1, kp.getCallCount()) << ",\n";
+  os << indent << "  \"kernel-type\": " << to_string(kp.getKernelType())
+     << '\n';
+  os << indent << '}';
+}
+
+void json_format_kernel_list(double totalExecuteTime,
+                             std::vector<KernelPerformanceInfo*>& kernelInfo,
+                             std::ostream& fout) {
+  std::sort(kernelInfo.begin(), kernelInfo.end(), compareKernelPerformanceInfo);
+  uint64_t totalKernelsCalls = 0;
+  double totalKernelsTime    = 0;
+  for (unsigned int i = 0; i < kernelInfo.size(); i++) {
+    if (kernelInfo[i]->getKernelType() != REGION) {
+      totalKernelsTime += kernelInfo[i]->getTime();
+      totalKernelsCalls += kernelInfo[i]->getCallCount();
+    }
+  }
+
+  // std::string filename = "test.json";
+  // std::ofstream fout(filename);
+
+  fout << "{\n";
+
+  fout << "  \"total-app-time\" : " << totalExecuteTime << ",\n";
+  fout << "  \"total-kernel-time\" : " << totalKernelsTime << ",\n";
+  fout << "  \"total-non-kernel-time\" : "
+       << totalExecuteTime - totalKernelsTime << ",\n";
+  fout << "  \"percent-in-kernels\" : "
+       << 100. * totalKernelsTime / totalExecuteTime << ",\n";
+  fout << "  \"unique-kernel-calls\" : " << totalKernelsCalls << ",\n";
+
+  fout << "  \"region-data\" : [\n";
+  {
+    bool add_comma = false;
+    for (auto const& kp : kernelInfo) {
+      if (!is_region(*kp)) continue;
+      if (add_comma) fout << ",\n";
+      add_comma = true;
+      write_json(fout, *kp, "    ");
+    }
+    fout << '\n';
+  }
+  fout << "  ],\n";
+
+  fout << "  \"kernel-data\" : [\n";
+  {
+    bool add_comma = false;
+    for (auto const& kp : kernelInfo) {
+      if (is_region(*kp)) continue;
+      if (add_comma) fout << ",\n";
+      add_comma = true;
+      write_json(fout, *kp, "    ");
+    }
+    fout << '\n';
+  }
+  fout << "  ]\n";
+
+  fout << "}\n";
 }
 
 }  // namespace KernelTimer

--- a/profiling/simple-kernel-timer/kp_shared.h
+++ b/profiling/simple-kernel-timer/kp_shared.h
@@ -39,6 +39,14 @@ inline int find_index(const std::vector<KernelPerformanceInfo*>& kernels,
   return -1;
 }
 
+inline bool is_region(KernelPerformanceInfo const& kp) {
+  return kp.getKernelType() == REGION;
+}
+
+void json_format_kernel_list(double totalExecuteTime,
+                             std::vector<KernelPerformanceInfo*>& kernelInfo,
+                             std::ostream& fout);
+
 }  // namespace KokkosTools::KernelTimer
 
 #endif  // _H_KOKKOSP_KERNEL_SHARED


### PR DESCRIPTION
## Problem 
`kp_kernel_timer` miscalculated total time, kernel count, and total kernel time in JSON output. Problem was not present in `kp_reader_json'and 'kp_reader` implementation.

## Fix 
Reused `kp_reader_json`'s logic and unified code in kp_shared.

## Impact 
- JSON outputs correct values
- Explicitly linked `kp_reader_json` to `kp_shared`


