### PR TITLE
[kp_kernel_filter]: Use beginReduceCallee when forwarding reduce events

### DIFF
--- a/common/kernel-filter/kp_kernel_filter.cpp
+++ b/common/kernel-filter/kp_kernel_filter.cpp
@@ -290,7 +290,7 @@ extern "C" void kokkosp_begin_parallel_reduce(const char* name,
                                               uint64_t* kID) {
   if (filterKernels) {
     if (kokkospFilterMatch(name)) {
-      if (NULL != beginScanCallee) {
+      if (NULL != beginReduceCallee) {
         (*beginReduceCallee)(name, devID, kID);
         activeKernels.insert(*kID);
       } else {
@@ -300,7 +300,7 @@ extern "C" void kokkosp_begin_parallel_reduce(const char* name,
       *kID = nextKernelID++;
     }
   } else {
-    if (NULL != beginScanCallee) {
+    if (NULL != beginReduceCallee) {
       (*beginReduceCallee)(name, devID, kID);
       activeKernels.insert(*kID);
     } else {


### PR DESCRIPTION
Likely an oversight.
We want to overhaul testing so I am not concerned with testing / catching such things right now.
