### PR TITLE
CMAKE_CXX_EXTENSIONS OFF for builds with nvcc_wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,18 @@ option(KokkosTools_ENABLE_TESTS    "Build tests"                    OFF)
 
 # Fetch Kokkos options:
 acquire_kokkos_config()
+if(Kokkos_DEVICES MATCHES "CUDA" AND COMMAND kokkos_compiler_is_nvcc)
+  kokkos_compiler_is_nvcc(IS_NVCC ${CMAKE_CXX_COMPILER})
+  if(IS_NVCC OR Kokkos_CXX_COMPILER_ID STREQUAL "Clang")
+    if(NOT DEFINED CMAKE_CXX_EXTENSIONS OR CMAKE_CXX_EXTENSIONS)
+      message(
+        WARNING
+        "The installed Kokkos configuration does not support CXX extensions. Forcing -DCMAKE_CXX_EXTENSIONS=Off"
+      )
+      set(CMAKE_CXX_EXTENSIONS OFF CACHE BOOL "" FORCE)
+    endif()
+  endif()
+endif()
 if(DEFINED Kokkos_FOUND_MSG)
   message(STATUS "${Kokkos_FOUND_MSG}: ${Kokkos_INSTALL_DIR}\n"
     "\t\tDevices: ${Kokkos_DEVICES}\n"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,6 +7,7 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_CXX_STANDARD": "20",
+        "CMAKE_CXX_EXTENSIONS": "OFF",
         "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror",
         "KokkosTools_ENABLE_EXAMPLES": "ON",
         "KokkosTools_ENABLE_SINGLE": "ON",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,7 +7,6 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_CXX_STANDARD": "20",
-        "CMAKE_CXX_EXTENSIONS": "OFF",
         "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror",
         "KokkosTools_ENABLE_EXAMPLES": "ON",
         "KokkosTools_ENABLE_SINGLE": "ON",

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -47,6 +47,8 @@ function(acquire_kokkos_config)
       Kokkos_ENABLE_OPENMP Kokkos_ENABLE_CUDA Kokkos_ENABLE_HIP
       # Kokkos exports the flags as well
       CMAKE_CXX_FLAGS)
-    set(${VAR_NAME} ${${VAR_NAME}} PARENT_SCOPE)
+    if(DEFINED ${VAR_NAME})
+      set(${VAR_NAME} ${${VAR_NAME}} PARENT_SCOPE)
+    endif()
   endforeach()
 endfunction()


### PR DESCRIPTION
Two changes;
- Force strict C++20 for CUDA builds with nvcc_wrapper otherwise we get the warning [1]
- Only export defined Kokkos variables from acquire_kokkos_config if they were defined

[1] warning
```bash
nvcc_wrapper has been given GNU extension standard flag -std=gnu++20 - reverting flag to -std=c++20
```
